### PR TITLE
Composability: let the NFT asset react to permissions being set

### DIFF
--- a/contracts/Sacd.sol
+++ b/contracts/Sacd.sol
@@ -7,6 +7,7 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol';
 
 import './interfaces/ISacd.sol';
+import './interfaces/ISacdListener.sol';
 
 /**
  * @title Service Access Contract Definition (SACD)
@@ -88,6 +89,10 @@ contract Sacd is ISacd, Initializable, AccessControlUpgradeable, UUPSUpgradeable
       $.permissionRecords[asset][tokenId][tokenIdVersion][grantee] = PermissionRecord(permissions, expiration, source);
 
       emit PermissionsSet(asset, tokenId, permissions, grantee, expiration, source);
+
+      try ISacdListener(asset).onSetPermissions(tokenId, grantee, permissions, expiration) {} catch {
+        // Ignore if the asset does not implement onSetPermissions
+      }
     } catch {
       revert InvalidTokenId(asset, tokenId);
     }

--- a/contracts/interfaces/ISacdListener.sol
+++ b/contracts/interfaces/ISacdListener.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title ISacdListener
+ * @dev Interface for reacting to calls to the Service Access Contract Definition (SACD)
+ * ERC721 token contracts that implement the ISacdListener interface can execute custom logic when SACD permissions change
+ */
+interface ISacdListener {
+  /**
+   * @dev Handles the event when permissions are set for the ERC721 token
+   * @param tokenId The ID of the token for which permissions are being set.
+   * @param grantee The address to receive the permission
+   * @param permissions The uint256 that represents the byte array of permissions
+   * @param expiration Expiration of the permissions
+   */
+  function onSetPermissions(uint256 tokenId, address grantee, uint256 permissions, uint256 expiration) external;
+}

--- a/contracts/mocks/MockERC721.sol
+++ b/contracts/mocks/MockERC721.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
+
+import '../interfaces/ISacd.sol';
+
+/**
+ * @title MockERC721
+ * @dev Mocks a generic ERC721 to be used in tests
+ */
+contract MockERC721 is ERC721 {
+  constructor() ERC721('Mock DIMO', 'MD') {}
+
+  function mint(address account) external {
+    _mint(account, 1);
+  }
+}

--- a/contracts/mocks/MockERC721withSacd.sol
+++ b/contracts/mocks/MockERC721withSacd.sol
@@ -4,12 +4,13 @@ pragma solidity ^0.8.24;
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 
 import '../interfaces/ISacd.sol';
+import '../interfaces/ISacdListener.sol';
 
 /**
  * @title MockERC721withSacd
  * @dev Mocks a generic ERC721 to be used in tests
  */
-contract MockERC721withSacd is ERC721 {
+contract MockERC721withSacd is ERC721, ISacdListener {
   struct SacdInput {
     address grantee;
     uint256 permissions;
@@ -19,6 +20,8 @@ contract MockERC721withSacd is ERC721 {
 
   uint256 tokenCount;
   address sacd;
+
+  event MockPermissionsSet(uint256 tokenId, address grantee, uint256 permissions, uint256 expiration);
 
   constructor(address _sacd) ERC721('Mock DIMO', 'MD') {
     sacd = _sacd;
@@ -47,5 +50,15 @@ contract MockERC721withSacd is ERC721 {
   function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
     ISacd(sacd).onTransfer(address(this), tokenId);
     return super._update(to, tokenId, auth);
+  }
+
+  function onSetPermissions(
+    uint256 tokenId,
+    address grantee,
+    uint256 permissions,
+    uint256 expiration
+  ) external override {
+    require(msg.sender == sacd, 'Unauthorized');
+    emit MockPermissionsSet(tokenId, grantee, permissions, expiration);
   }
 }

--- a/test/Sacd.test.ts
+++ b/test/Sacd.test.ts
@@ -126,7 +126,7 @@ describe('Sacd', function () {
       })
     })
 
-    context('Events', () => {
+    context('Events and callbacks', () => {
       it('Should emit PermissionsSet with correct params', async () => {
         const { mockErc721, sacd, grantor, grantee, DEFAULT_EXPIRATION } = await loadFixture(setup)
         const mockErc721Address = await mockErc721.getAddress()
@@ -145,6 +145,43 @@ describe('Sacd', function () {
         )
           .to.emit(sacd, 'PermissionsSet')
           .withArgs(mockErc721Address, 1n, C.MOCK_PERMISSIONS, grantee.address, DEFAULT_EXPIRATION, C.MOCK_SOURCE)
+      })
+
+      it('Should call onSetPermissions with correct params', async () => {
+        const { mockErc721, sacd, grantor, grantee, DEFAULT_EXPIRATION } = await loadFixture(setup)
+        const mockErc721Address = await mockErc721.getAddress()
+
+        await expect(
+          sacd
+            .connect(grantor)
+            .setPermissions(
+              mockErc721Address,
+              1n,
+              grantee.address,
+              C.MOCK_PERMISSIONS,
+              DEFAULT_EXPIRATION,
+              C.MOCK_SOURCE
+            )
+        )
+          .to.emit(mockErc721, 'MockPermissionsSet')
+          .withArgs(1n, grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION)
+      })
+
+      it('Should work even if NFT does not implement onSetPermissions', async () => {
+        const [, grantor, grantee] = await hre.ethers.getSigners()
+        const mockErc721Factory = await hre.ethers.getContractFactory('MockERC721')
+
+        const sacd = (await ignition.deploy(SacdModule)).sacd as unknown as Sacd
+        const mockErc721 = await mockErc721Factory.deploy()
+        await mockErc721.mint(grantor.address)
+
+        await expect(
+          sacd
+            .connect(grantor)
+            .setPermissions(await mockErc721.getAddress(), 1n, grantee.address, C.MOCK_PERMISSIONS, 0n, C.MOCK_SOURCE)
+        )
+          .to.emit(sacd, 'PermissionsSet')
+          .withArgs(await mockErc721.getAddress(), 1n, C.MOCK_PERMISSIONS, grantee.address, 0n, C.MOCK_SOURCE)
       })
     })
 


### PR DESCRIPTION
If the NFT has state that depends on the SACD permissions, currently there's no way for it to know the permissions changed (before someone calling it after permission change). This is similar to a contract receiving ERC20 tokens: the contract doesn't get notified. It's in contrast to a contract receiving ether: the receiving contract gets a chance to update its state (fallback / receive function). This is quite beneficial to composing smart contracts: if setting SACD permission activates the target NFT as well, it can keep its own state updated, so that all contracts stay in sync.
