### PR TITLE
Let grantees renounce permissions

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,205 @@
+# Upgrading SACD Contracts
+
+Runbook for upgrading the deployed `Sacd` and `Template` contracts on Polygon and Amoy. Both are UUPS proxies — upgrades replace the implementation contract while keeping the proxy address (and therefore all storage and integrations) untouched.
+
+If you're deploying to a brand-new chain instead of upgrading an existing one, this is the wrong document — see the **Deploy** section in the [README](./README.md) and use Hardhat Ignition.
+
+## What you're actually doing
+
+Each upgrade is two transactions:
+
+1. Deploy a new implementation contract.
+2. Call `upgradeToAndCall(newImpl, "0x")` on the proxy. This is gated by `UPGRADER_ROLE` on the proxy.
+
+Step 1 is permissionless — any funded EOA can do it. Step 2 must be sent from whoever holds `UPGRADER_ROLE`.
+
+## Roles and addresses
+
+| Network | Chain ID | Sacd proxy | Template proxy | `UPGRADER_ROLE` holder |
+|---|---|---|---|---|
+| Polygon | 137 | `0x3c152B5d96769661008Ff404224d6530FCAC766d` | `0x666309adbec298bb332c722f0303ce883f895750` | Deployer Safe `0xCED3c922200559128930180d3f0bfFd4d9f4F123` |
+| Amoy | 80002 | `0x4E5F9320b1c7cB3DE5ebDD760aD67375B66cF8a3` | `0x666309adbec298bb332c722f0303ce883f895750` | Shared dev EOA `0xC008EF40B0b42AAD7e34879EB024385024f753ea` |
+
+Other relevant addresses (commented in `scripts/upgrade.ts`):
+
+- `0xD64b27cA7F7d4447dFa8cb8701497Fb6eE774F6a` — designated CREATE3 deployer (used for Template impls; salt-bound, do not change)
+- `0x1741ec2915ab71fc03492715b5640133da69420b` — historical Polygon EOA manager; not the upgrader anymore (Safe is)
+
+`scripts/data/addresses.json` is the source of truth for proxy and current implementation addresses. The `ignition/deployments/` directory only records the original deploy and is **not** updated by upgrades.
+
+## Pre-flight checklist
+
+Run these before doing anything irreversible.
+
+### 1. Confirm what changed
+
+```sh
+git diff <last-deploy-commit>..HEAD -- contracts/
+```
+
+Look at the prior `upgrade sacd <Network>` commits (e.g. `940a209`, `993a0ad`) for what was last deployed. Anything that changes contract bytecode or interfaces is a candidate for upgrade.
+
+### 2. Confirm storage layout is compatible
+
+UUPS upgrades reuse the existing storage. Adding new storage variables is fine **only** if they're appended (or added inside the namespaced ERC-7201 storage struct, which both `Sacd` and `Template` use). Reordering, deleting, or changing the type of existing storage will corrupt state.
+
+For `Sacd` the namespaced struct is `SacdStorage` in `contracts/Sacd.sol`. Diff it:
+
+```sh
+git diff <last-deploy-commit>..HEAD -- contracts/Sacd.sol | grep -A 20 'struct SacdStorage'
+```
+
+Pure function/event additions (like the `renounce*` commit) are always safe.
+
+### 3. Confirm the UPGRADER_ROLE holder
+
+The table above is current as of the last update to this doc. To re-verify on-chain:
+
+```sh
+UPGRADER_ROLE=$(cast keccak "UPGRADER_ROLE")
+
+# Polygon — expect true for the Safe
+cast call 0x3c152B5d96769661008Ff404224d6530FCAC766d \
+  'hasRole(bytes32,address)(bool)' \
+  $UPGRADER_ROLE 0xCED3c922200559128930180d3f0bfFd4d9f4F123 \
+  --rpc-url $POLYGON_URL
+
+# Amoy — expect true for the shared dev EOA
+cast call 0x4E5F9320b1c7cB3DE5ebDD760aD67375B66cF8a3 \
+  'hasRole(bytes32,address)(bool)' \
+  $UPGRADER_ROLE 0xC008EF40B0b42AAD7e34879EB024385024f753ea \
+  --rpc-url $AMOY_URL
+```
+
+If the answer changes, update the table and `scripts/data/addresses.json` (`safe` field for Polygon).
+
+### 4. Confirm current implementation matches `addresses.json`
+
+```sh
+# EIP-1967 implementation slot
+cast storage 0x3c152B5d96769661008Ff404224d6530FCAC766d \
+  0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc \
+  --rpc-url $POLYGON_URL
+```
+
+The lower 20 bytes should match `polygon.Sacd.implementation` in `scripts/data/addresses.json`. If it doesn't, someone upgraded out-of-band — sort that out before continuing.
+
+### 5. Set up `.env`
+
+```
+POLYGON_URL=...
+AMOY_URL=...
+PRIVATE_KEY=<EOA with funds — used for impl deployment on real network and as the upgrader on Amoy>
+POLYGONSCAN_API_KEY=<for verification>
+```
+
+The `PRIVATE_KEY` only needs `UPGRADER_ROLE` on Amoy. On Polygon it just needs gas — the upgrade tx is sent from the Safe, not this EOA.
+
+## Simulate first
+
+Always rehearse against a fork. The simulation impersonates the same address that will sign the real tx and exercises the full upgrade end-to-end.
+
+### Polygon (Safe path)
+
+Terminal 1 — start a fork:
+
+```sh
+npx hardhat node --fork $POLYGON_URL
+```
+
+Terminal 2 — run the upgrade script in safe mode against `localhost`:
+
+```sh
+CONTRACT=sacd MODE=safe FORK=polygon npx hardhat run scripts/upgrade.ts --network localhost
+```
+
+This deploys a fresh impl on the fork, impersonates the Safe at `0xCED3…F123`, and calls `upgradeToAndCall`. Then poke at the upgraded proxy to confirm the new behavior:
+
+```sh
+# In a hardhat console pointed at localhost, or an inline script:
+const sacd = await ethers.getContractAt('Sacd', '0x3c152B5d96769661008Ff404224d6530FCAC766d')
+await sacd.renounceAccountPermissions('0xSomeGrantor')   // should not revert
+```
+
+Whatever golden-path call exercises the new code goes here.
+
+### Amoy (EOA path)
+
+```sh
+npx hardhat node --fork $AMOY_URL
+# in another shell
+FORK=amoy CONTRACT=sacd npx hardhat run scripts/upgrade.ts --network localhost
+```
+
+This impersonates the shared dev EOA `0xC008…3ea`, deploys impl, and upgrades the proxy in one go.
+
+### Resetting after a simulation
+
+The simulation step writes the simulated impl address into `scripts/data/addresses.json`. Discard those changes (`git checkout scripts/data/addresses.json`) before doing the real run, otherwise you'll be pointing at a non-existent address.
+
+## Real upgrade — Amoy (EOA path)
+
+```sh
+CONTRACT=sacd npx hardhat run scripts/upgrade.ts --network amoy
+```
+
+This deploys impl from `PRIVATE_KEY`, calls `upgradeToAndCall`, and writes the new impl into `scripts/data/addresses.json`.
+
+For Template:
+
+```sh
+CONTRACT=template-impl VERSION=1.0.x npx hardhat run scripts/upgrade.ts --network amoy
+CONTRACT=template-proxy npx hardhat run scripts/upgrade.ts --network amoy
+```
+
+(Template uses CREATE3 for deterministic addresses, so the version bump is required to get a new salt.)
+
+## Real upgrade — Polygon (Safe path)
+
+```sh
+CONTRACT=sacd MODE=safe npx hardhat run scripts/upgrade.ts --network polygon
+```
+
+This:
+
+1. Deploys the new impl from `PRIVATE_KEY` (any funded EOA — the impl is not access-controlled).
+2. Writes the new impl into `scripts/data/addresses.json`.
+3. Prints the `upgradeToAndCall(newImpl, "0x")` calldata and a Safe Tx Builder JSON blob.
+
+Then in the Safe UI:
+
+1. Open the Safe at `0xCED3…F123` on Polygon.
+2. Apps → **Tx Builder** → **Import** → paste the JSON.
+3. Submit, collect the required signatures, execute.
+
+After execution, re-verify the implementation slot (see pre-flight check 4) matches the new address.
+
+For Template on Polygon, there isn't yet a `MODE=safe` branch for the Template flow. If `UPGRADER_ROLE` on the Template proxy is also held by the Safe, you'd need to:
+
+1. `CONTRACT=template-impl VERSION=1.0.x npx hardhat run scripts/upgrade.ts --network polygon` (deploy impl via CREATE3 — the designated CREATE3 deployer EOA must be the signer for that step).
+2. Manually build the `upgradeToAndCall(newImpl, "0x")` calldata for the Template proxy and submit through the Safe.
+
+If you find yourself doing this often, extend `scripts/upgrade.ts` with a `template-proxy-safe` branch that mirrors the Sacd safe path.
+
+## Post-upgrade
+
+1. Verify on-chain: re-run pre-flight check 4 and confirm the impl slot points to the new address on every network you upgraded.
+2. Verify on Polygonscan / Amoy Polygonscan:
+   ```sh
+   npx hardhat ignition verify chain-137
+   npx hardhat ignition verify chain-80002
+   ```
+   (If `ignition verify` doesn't pick up the new impl because it was deployed outside Ignition, fall back to `npx hardhat verify --network polygon <newImpl>` with no constructor args.)
+3. Smoke-test against the real proxy with a read or a cheap write that exercises the new code path.
+4. Commit the `scripts/data/addresses.json` change. Match the existing style:
+   ```
+   upgrade sacd Polygon
+   upgrade sacd Amoy
+   ```
+5. If any consumers (devices-api, etc.) need the new ABI or Go bindings, regenerate them: `npm run abigen` and copy from `bindings/`.
+
+## Reference: what changes per upgrade
+
+- `scripts/data/addresses.json` — `Sacd.implementation` (and/or `Template.implementation`) for the network you upgraded. This is the only file the script writes.
+- `ignition/deployments/` — **not** touched by upgrades. Don't be alarmed that the addresses there are stale.
+- `bindings/` and `abis/` — only if the public ABI changed and downstream consumers need it.

--- a/abis/contracts/Sacd.sol/Sacd.json
+++ b/abis/contracts/Sacd.sol/Sacd.json
@@ -250,6 +250,31 @@
         "type": "uint256"
       },
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "grantee",
+        "type": "address"
+      }
+    ],
+    "name": "PermissionsRenounced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
         "indexed": false,
         "internalType": "uint256",
         "name": "permissions",
@@ -978,6 +1003,37 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "grantor",
+        "type": "address"
+      }
+    ],
+    "name": "renounceAccountPermissions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "renouncePermissions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/bindings/sacd/sacd.go
+++ b/bindings/sacd/sacd.go
@@ -42,7 +42,7 @@ type ISacdPermissionRecord struct {
 
 // SacdMetaData contains all meta data concerning the Sacd contract.
 var SacdMetaData = bind.MetaData{
-	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"AccessControlBadConfirmation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"neededRole\",\"type\":\"bytes32\"}],\"name\":\"AccessControlUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"AddressEmptyCode\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"ERC1967InvalidImplementation\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ERC1967NonPayable\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedInnerCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidCurrency\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"InvalidTokenId\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"expectedAsset\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"providedAsset\",\"type\":\"address\"}],\"name\":\"TemplateAssetMismatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"TemplateContractNotSet\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"}],\"name\":\"TemplateNotActive\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expectedPermissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"providedPermissions\",\"type\":\"uint256\"}],\"name\":\"TemplatePermissionsMismatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UUPSUnauthorizedCallContext\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"slot\",\"type\":\"bytes32\"}],\"name\":\"UUPSUnsupportedProxiableUUID\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"Unauthorized\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroAddress\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"PaymentSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"PermissionsSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"previousAdminRole\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"newAdminRole\",\"type\":\"bytes32\"}],\"name\":\"RoleAdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleGranted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleRevoked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DEFAULT_ADMIN_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"UPGRADE_INTERFACE_VERSION\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"}],\"name\":\"accountPermissionRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"}],\"internalType\":\"structISacd.PermissionRecord\",\"name\":\"permissionRecord\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"}],\"name\":\"currentPaymentRecord\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"expiration\",\"type\":\"uint64\"},{\"internalType\":\"bytes3\",\"name\":\"currency\",\"type\":\"bytes3\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"internalType\":\"structISacd.PaymentRecord\",\"name\":\"paymentRecord\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"}],\"name\":\"currentPermissionRecord\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"}],\"internalType\":\"structISacd.PermissionRecord\",\"name\":\"permissionRecord\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"}],\"name\":\"getAccountPermissions\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"}],\"name\":\"getPermissions\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleAdmin\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"grantRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"permissionIndex\",\"type\":\"uint8\"}],\"name\":\"hasAccountPermission\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"}],\"name\":\"hasAccountPermissions\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"permissionIndex\",\"type\":\"uint8\"}],\"name\":\"hasPermission\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"}],\"name\":\"hasPermissions\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"hasRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"templateContractAddress\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"}],\"name\":\"nextPaymentId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"paymentId\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"onTransfer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"paymentId\",\"type\":\"uint256\"}],\"name\":\"paymentRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"expiration\",\"type\":\"uint64\"},{\"internalType\":\"bytes3\",\"name\":\"currency\",\"type\":\"bytes3\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"internalType\":\"structISacd.PaymentRecord\",\"name\":\"paymentRecord\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"version\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"}],\"name\":\"permissionRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"}],\"internalType\":\"structISacd.PermissionRecord\",\"name\":\"permissionRecord\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proxiableUUID\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"callerConfirmation\",\"type\":\"address\"}],\"name\":\"renounceRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"revokeRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"setAccountPermissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"expiration\",\"type\":\"uint64\"},{\"internalType\":\"bytes3\",\"name\":\"currency\",\"type\":\"bytes3\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"setPayment\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"setPermissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"setPermissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"templateContractAddress\",\"type\":\"address\"}],\"name\":\"setTemplateContract\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"templateContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"template_\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"tokenIdToVersion\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"version\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newImplementation\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"upgradeToAndCall\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"}]",
+	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"AccessControlBadConfirmation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"neededRole\",\"type\":\"bytes32\"}],\"name\":\"AccessControlUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"AddressEmptyCode\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"ERC1967InvalidImplementation\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ERC1967NonPayable\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedInnerCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidCurrency\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"InvalidTokenId\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"expectedAsset\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"providedAsset\",\"type\":\"address\"}],\"name\":\"TemplateAssetMismatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"TemplateContractNotSet\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"}],\"name\":\"TemplateNotActive\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expectedPermissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"providedPermissions\",\"type\":\"uint256\"}],\"name\":\"TemplatePermissionsMismatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UUPSUnauthorizedCallContext\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"slot\",\"type\":\"bytes32\"}],\"name\":\"UUPSUnsupportedProxiableUUID\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"Unauthorized\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroAddress\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"PaymentSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"}],\"name\":\"PermissionsRenounced\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"PermissionsSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"previousAdminRole\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"newAdminRole\",\"type\":\"bytes32\"}],\"name\":\"RoleAdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleGranted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleRevoked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DEFAULT_ADMIN_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"UPGRADE_INTERFACE_VERSION\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"}],\"name\":\"accountPermissionRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"}],\"internalType\":\"structISacd.PermissionRecord\",\"name\":\"permissionRecord\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"}],\"name\":\"currentPaymentRecord\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"expiration\",\"type\":\"uint64\"},{\"internalType\":\"bytes3\",\"name\":\"currency\",\"type\":\"bytes3\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"internalType\":\"structISacd.PaymentRecord\",\"name\":\"paymentRecord\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"}],\"name\":\"currentPermissionRecord\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"}],\"internalType\":\"structISacd.PermissionRecord\",\"name\":\"permissionRecord\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"}],\"name\":\"getAccountPermissions\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"}],\"name\":\"getPermissions\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleAdmin\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"grantRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"permissionIndex\",\"type\":\"uint8\"}],\"name\":\"hasAccountPermission\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"}],\"name\":\"hasAccountPermissions\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"permissionIndex\",\"type\":\"uint8\"}],\"name\":\"hasPermission\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"}],\"name\":\"hasPermissions\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"hasRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"templateContractAddress\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"}],\"name\":\"nextPaymentId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"paymentId\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"onTransfer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"paymentId\",\"type\":\"uint256\"}],\"name\":\"paymentRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"expiration\",\"type\":\"uint64\"},{\"internalType\":\"bytes3\",\"name\":\"currency\",\"type\":\"bytes3\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"internalType\":\"structISacd.PaymentRecord\",\"name\":\"paymentRecord\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"version\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"}],\"name\":\"permissionRecords\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"}],\"internalType\":\"structISacd.PermissionRecord\",\"name\":\"permissionRecord\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proxiableUUID\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"}],\"name\":\"renounceAccountPermissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"renouncePermissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"callerConfirmation\",\"type\":\"address\"}],\"name\":\"renounceRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"revokeRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"setAccountPermissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"grantor\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"expiration\",\"type\":\"uint64\"},{\"internalType\":\"bytes3\",\"name\":\"currency\",\"type\":\"bytes3\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"setPayment\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"templateId\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"setPermissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"grantee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"permissions\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiration\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"source\",\"type\":\"string\"}],\"name\":\"setPermissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"templateContractAddress\",\"type\":\"address\"}],\"name\":\"setTemplateContract\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"templateContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"template_\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"tokenIdToVersion\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"version\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newImplementation\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"upgradeToAndCall\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"}]",
 	ID:  "Sacd",
 }
 
@@ -67,7 +67,8 @@ func (c *Sacd) Instance(backend bind.ContractBackend, addr common.Address) *bind
 }
 
 // PackDEFAULTADMINROLE is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xa217fddf.
+// the contract method with ID 0xa217fddf.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
 func (sacd *Sacd) PackDEFAULTADMINROLE() []byte {
@@ -76,6 +77,15 @@ func (sacd *Sacd) PackDEFAULTADMINROLE() []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackDEFAULTADMINROLE is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xa217fddf.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (sacd *Sacd) TryPackDEFAULTADMINROLE() ([]byte, error) {
+	return sacd.abi.Pack("DEFAULT_ADMIN_ROLE")
 }
 
 // UnpackDEFAULTADMINROLE is the Go binding that unpacks the parameters returned
@@ -88,11 +98,12 @@ func (sacd *Sacd) UnpackDEFAULTADMINROLE(data []byte) ([32]byte, error) {
 		return *new([32]byte), err
 	}
 	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
-	return out0, err
+	return out0, nil
 }
 
 // PackUPGRADEINTERFACEVERSION is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xad3cb1cc.
+// the contract method with ID 0xad3cb1cc.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
 func (sacd *Sacd) PackUPGRADEINTERFACEVERSION() []byte {
@@ -101,6 +112,15 @@ func (sacd *Sacd) PackUPGRADEINTERFACEVERSION() []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackUPGRADEINTERFACEVERSION is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xad3cb1cc.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (sacd *Sacd) TryPackUPGRADEINTERFACEVERSION() ([]byte, error) {
+	return sacd.abi.Pack("UPGRADE_INTERFACE_VERSION")
 }
 
 // UnpackUPGRADEINTERFACEVERSION is the Go binding that unpacks the parameters returned
@@ -113,11 +133,12 @@ func (sacd *Sacd) UnpackUPGRADEINTERFACEVERSION(data []byte) (string, error) {
 		return *new(string), err
 	}
 	out0 := *abi.ConvertType(out[0], new(string)).(*string)
-	return out0, err
+	return out0, nil
 }
 
 // PackAccountPermissionRecords is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x30eaba75.
+// the contract method with ID 0x30eaba75.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function accountPermissionRecords(address grantor, address grantee) view returns((uint256,uint256,string,uint256) permissionRecord)
 func (sacd *Sacd) PackAccountPermissionRecords(grantor common.Address, grantee common.Address) []byte {
@@ -126,6 +147,15 @@ func (sacd *Sacd) PackAccountPermissionRecords(grantor common.Address, grantee c
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackAccountPermissionRecords is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x30eaba75.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function accountPermissionRecords(address grantor, address grantee) view returns((uint256,uint256,string,uint256) permissionRecord)
+func (sacd *Sacd) TryPackAccountPermissionRecords(grantor common.Address, grantee common.Address) ([]byte, error) {
+	return sacd.abi.Pack("accountPermissionRecords", grantor, grantee)
 }
 
 // UnpackAccountPermissionRecords is the Go binding that unpacks the parameters returned
@@ -138,11 +168,12 @@ func (sacd *Sacd) UnpackAccountPermissionRecords(data []byte) (ISacdPermissionRe
 		return *new(ISacdPermissionRecord), err
 	}
 	out0 := *abi.ConvertType(out[0], new(ISacdPermissionRecord)).(*ISacdPermissionRecord)
-	return out0, err
+	return out0, nil
 }
 
 // PackCurrentPaymentRecord is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x0f7d31f6.
+// the contract method with ID 0x0f7d31f6.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function currentPaymentRecord(address asset, address grantee, address grantor) view returns((uint256,uint64,bytes3,string) paymentRecord)
 func (sacd *Sacd) PackCurrentPaymentRecord(asset common.Address, grantee common.Address, grantor common.Address) []byte {
@@ -151,6 +182,15 @@ func (sacd *Sacd) PackCurrentPaymentRecord(asset common.Address, grantee common.
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackCurrentPaymentRecord is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x0f7d31f6.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function currentPaymentRecord(address asset, address grantee, address grantor) view returns((uint256,uint64,bytes3,string) paymentRecord)
+func (sacd *Sacd) TryPackCurrentPaymentRecord(asset common.Address, grantee common.Address, grantor common.Address) ([]byte, error) {
+	return sacd.abi.Pack("currentPaymentRecord", asset, grantee, grantor)
 }
 
 // UnpackCurrentPaymentRecord is the Go binding that unpacks the parameters returned
@@ -163,11 +203,12 @@ func (sacd *Sacd) UnpackCurrentPaymentRecord(data []byte) (ISacdPaymentRecord, e
 		return *new(ISacdPaymentRecord), err
 	}
 	out0 := *abi.ConvertType(out[0], new(ISacdPaymentRecord)).(*ISacdPaymentRecord)
-	return out0, err
+	return out0, nil
 }
 
 // PackCurrentPermissionRecord is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x426d9e4a.
+// the contract method with ID 0x426d9e4a.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function currentPermissionRecord(address asset, uint256 tokenId, address grantee) view returns((uint256,uint256,string,uint256) permissionRecord)
 func (sacd *Sacd) PackCurrentPermissionRecord(asset common.Address, tokenId *big.Int, grantee common.Address) []byte {
@@ -176,6 +217,15 @@ func (sacd *Sacd) PackCurrentPermissionRecord(asset common.Address, tokenId *big
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackCurrentPermissionRecord is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x426d9e4a.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function currentPermissionRecord(address asset, uint256 tokenId, address grantee) view returns((uint256,uint256,string,uint256) permissionRecord)
+func (sacd *Sacd) TryPackCurrentPermissionRecord(asset common.Address, tokenId *big.Int, grantee common.Address) ([]byte, error) {
+	return sacd.abi.Pack("currentPermissionRecord", asset, tokenId, grantee)
 }
 
 // UnpackCurrentPermissionRecord is the Go binding that unpacks the parameters returned
@@ -188,11 +238,12 @@ func (sacd *Sacd) UnpackCurrentPermissionRecord(data []byte) (ISacdPermissionRec
 		return *new(ISacdPermissionRecord), err
 	}
 	out0 := *abi.ConvertType(out[0], new(ISacdPermissionRecord)).(*ISacdPermissionRecord)
-	return out0, err
+	return out0, nil
 }
 
 // PackGetAccountPermissions is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x6805e547.
+// the contract method with ID 0x6805e547.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function getAccountPermissions(address grantor, address grantee, uint256 permissions) view returns(uint256)
 func (sacd *Sacd) PackGetAccountPermissions(grantor common.Address, grantee common.Address, permissions *big.Int) []byte {
@@ -201,6 +252,15 @@ func (sacd *Sacd) PackGetAccountPermissions(grantor common.Address, grantee comm
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackGetAccountPermissions is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x6805e547.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function getAccountPermissions(address grantor, address grantee, uint256 permissions) view returns(uint256)
+func (sacd *Sacd) TryPackGetAccountPermissions(grantor common.Address, grantee common.Address, permissions *big.Int) ([]byte, error) {
+	return sacd.abi.Pack("getAccountPermissions", grantor, grantee, permissions)
 }
 
 // UnpackGetAccountPermissions is the Go binding that unpacks the parameters returned
@@ -213,11 +273,12 @@ func (sacd *Sacd) UnpackGetAccountPermissions(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // PackGetPermissions is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x68233c61.
+// the contract method with ID 0x68233c61.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function getPermissions(address asset, uint256 tokenId, address grantee, uint256 permissions) view returns(uint256)
 func (sacd *Sacd) PackGetPermissions(asset common.Address, tokenId *big.Int, grantee common.Address, permissions *big.Int) []byte {
@@ -226,6 +287,15 @@ func (sacd *Sacd) PackGetPermissions(asset common.Address, tokenId *big.Int, gra
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackGetPermissions is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x68233c61.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function getPermissions(address asset, uint256 tokenId, address grantee, uint256 permissions) view returns(uint256)
+func (sacd *Sacd) TryPackGetPermissions(asset common.Address, tokenId *big.Int, grantee common.Address, permissions *big.Int) ([]byte, error) {
+	return sacd.abi.Pack("getPermissions", asset, tokenId, grantee, permissions)
 }
 
 // UnpackGetPermissions is the Go binding that unpacks the parameters returned
@@ -238,11 +308,12 @@ func (sacd *Sacd) UnpackGetPermissions(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // PackGetRoleAdmin is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x248a9ca3.
+// the contract method with ID 0x248a9ca3.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
 func (sacd *Sacd) PackGetRoleAdmin(role [32]byte) []byte {
@@ -251,6 +322,15 @@ func (sacd *Sacd) PackGetRoleAdmin(role [32]byte) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackGetRoleAdmin is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x248a9ca3.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (sacd *Sacd) TryPackGetRoleAdmin(role [32]byte) ([]byte, error) {
+	return sacd.abi.Pack("getRoleAdmin", role)
 }
 
 // UnpackGetRoleAdmin is the Go binding that unpacks the parameters returned
@@ -263,11 +343,12 @@ func (sacd *Sacd) UnpackGetRoleAdmin(data []byte) ([32]byte, error) {
 		return *new([32]byte), err
 	}
 	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
-	return out0, err
+	return out0, nil
 }
 
 // PackGrantRole is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x2f2ff15d.
+// the contract method with ID 0x2f2ff15d.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function grantRole(bytes32 role, address account) returns()
 func (sacd *Sacd) PackGrantRole(role [32]byte, account common.Address) []byte {
@@ -278,8 +359,18 @@ func (sacd *Sacd) PackGrantRole(role [32]byte, account common.Address) []byte {
 	return enc
 }
 
+// TryPackGrantRole is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x2f2ff15d.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (sacd *Sacd) TryPackGrantRole(role [32]byte, account common.Address) ([]byte, error) {
+	return sacd.abi.Pack("grantRole", role, account)
+}
+
 // PackHasAccountPermission is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x4fbaaafd.
+// the contract method with ID 0x4fbaaafd.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function hasAccountPermission(address grantor, address grantee, uint8 permissionIndex) view returns(bool)
 func (sacd *Sacd) PackHasAccountPermission(grantor common.Address, grantee common.Address, permissionIndex uint8) []byte {
@@ -288,6 +379,15 @@ func (sacd *Sacd) PackHasAccountPermission(grantor common.Address, grantee commo
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackHasAccountPermission is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x4fbaaafd.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function hasAccountPermission(address grantor, address grantee, uint8 permissionIndex) view returns(bool)
+func (sacd *Sacd) TryPackHasAccountPermission(grantor common.Address, grantee common.Address, permissionIndex uint8) ([]byte, error) {
+	return sacd.abi.Pack("hasAccountPermission", grantor, grantee, permissionIndex)
 }
 
 // UnpackHasAccountPermission is the Go binding that unpacks the parameters returned
@@ -300,11 +400,12 @@ func (sacd *Sacd) UnpackHasAccountPermission(data []byte) (bool, error) {
 		return *new(bool), err
 	}
 	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
-	return out0, err
+	return out0, nil
 }
 
 // PackHasAccountPermissions is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x64e2cd2c.
+// the contract method with ID 0x64e2cd2c.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function hasAccountPermissions(address grantor, address grantee, uint256 permissions) view returns(bool)
 func (sacd *Sacd) PackHasAccountPermissions(grantor common.Address, grantee common.Address, permissions *big.Int) []byte {
@@ -313,6 +414,15 @@ func (sacd *Sacd) PackHasAccountPermissions(grantor common.Address, grantee comm
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackHasAccountPermissions is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x64e2cd2c.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function hasAccountPermissions(address grantor, address grantee, uint256 permissions) view returns(bool)
+func (sacd *Sacd) TryPackHasAccountPermissions(grantor common.Address, grantee common.Address, permissions *big.Int) ([]byte, error) {
+	return sacd.abi.Pack("hasAccountPermissions", grantor, grantee, permissions)
 }
 
 // UnpackHasAccountPermissions is the Go binding that unpacks the parameters returned
@@ -325,11 +435,12 @@ func (sacd *Sacd) UnpackHasAccountPermissions(data []byte) (bool, error) {
 		return *new(bool), err
 	}
 	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
-	return out0, err
+	return out0, nil
 }
 
 // PackHasPermission is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x48eb48f5.
+// the contract method with ID 0x48eb48f5.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function hasPermission(address asset, uint256 tokenId, address grantee, uint8 permissionIndex) view returns(bool)
 func (sacd *Sacd) PackHasPermission(asset common.Address, tokenId *big.Int, grantee common.Address, permissionIndex uint8) []byte {
@@ -338,6 +449,15 @@ func (sacd *Sacd) PackHasPermission(asset common.Address, tokenId *big.Int, gran
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackHasPermission is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x48eb48f5.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function hasPermission(address asset, uint256 tokenId, address grantee, uint8 permissionIndex) view returns(bool)
+func (sacd *Sacd) TryPackHasPermission(asset common.Address, tokenId *big.Int, grantee common.Address, permissionIndex uint8) ([]byte, error) {
+	return sacd.abi.Pack("hasPermission", asset, tokenId, grantee, permissionIndex)
 }
 
 // UnpackHasPermission is the Go binding that unpacks the parameters returned
@@ -350,11 +470,12 @@ func (sacd *Sacd) UnpackHasPermission(data []byte) (bool, error) {
 		return *new(bool), err
 	}
 	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
-	return out0, err
+	return out0, nil
 }
 
 // PackHasPermissions is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x16bc016c.
+// the contract method with ID 0x16bc016c.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function hasPermissions(address asset, uint256 tokenId, address grantee, uint256 permissions) view returns(bool)
 func (sacd *Sacd) PackHasPermissions(asset common.Address, tokenId *big.Int, grantee common.Address, permissions *big.Int) []byte {
@@ -363,6 +484,15 @@ func (sacd *Sacd) PackHasPermissions(asset common.Address, tokenId *big.Int, gra
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackHasPermissions is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x16bc016c.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function hasPermissions(address asset, uint256 tokenId, address grantee, uint256 permissions) view returns(bool)
+func (sacd *Sacd) TryPackHasPermissions(asset common.Address, tokenId *big.Int, grantee common.Address, permissions *big.Int) ([]byte, error) {
+	return sacd.abi.Pack("hasPermissions", asset, tokenId, grantee, permissions)
 }
 
 // UnpackHasPermissions is the Go binding that unpacks the parameters returned
@@ -375,11 +505,12 @@ func (sacd *Sacd) UnpackHasPermissions(data []byte) (bool, error) {
 		return *new(bool), err
 	}
 	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
-	return out0, err
+	return out0, nil
 }
 
 // PackHasRole is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x91d14854.
+// the contract method with ID 0x91d14854.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function hasRole(bytes32 role, address account) view returns(bool)
 func (sacd *Sacd) PackHasRole(role [32]byte, account common.Address) []byte {
@@ -388,6 +519,15 @@ func (sacd *Sacd) PackHasRole(role [32]byte, account common.Address) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackHasRole is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x91d14854.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (sacd *Sacd) TryPackHasRole(role [32]byte, account common.Address) ([]byte, error) {
+	return sacd.abi.Pack("hasRole", role, account)
 }
 
 // UnpackHasRole is the Go binding that unpacks the parameters returned
@@ -400,11 +540,12 @@ func (sacd *Sacd) UnpackHasRole(data []byte) (bool, error) {
 		return *new(bool), err
 	}
 	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
-	return out0, err
+	return out0, nil
 }
 
 // PackInitialize is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xc4d66de8.
+// the contract method with ID 0xc4d66de8.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function initialize(address templateContractAddress) returns()
 func (sacd *Sacd) PackInitialize(templateContractAddress common.Address) []byte {
@@ -415,8 +556,18 @@ func (sacd *Sacd) PackInitialize(templateContractAddress common.Address) []byte 
 	return enc
 }
 
+// TryPackInitialize is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xc4d66de8.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function initialize(address templateContractAddress) returns()
+func (sacd *Sacd) TryPackInitialize(templateContractAddress common.Address) ([]byte, error) {
+	return sacd.abi.Pack("initialize", templateContractAddress)
+}
+
 // PackNextPaymentId is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x8f4390ac.
+// the contract method with ID 0x8f4390ac.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function nextPaymentId(address asset, address grantee, address grantor) view returns(uint256 paymentId)
 func (sacd *Sacd) PackNextPaymentId(asset common.Address, grantee common.Address, grantor common.Address) []byte {
@@ -425,6 +576,15 @@ func (sacd *Sacd) PackNextPaymentId(asset common.Address, grantee common.Address
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackNextPaymentId is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x8f4390ac.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function nextPaymentId(address asset, address grantee, address grantor) view returns(uint256 paymentId)
+func (sacd *Sacd) TryPackNextPaymentId(asset common.Address, grantee common.Address, grantor common.Address) ([]byte, error) {
+	return sacd.abi.Pack("nextPaymentId", asset, grantee, grantor)
 }
 
 // UnpackNextPaymentId is the Go binding that unpacks the parameters returned
@@ -437,11 +597,12 @@ func (sacd *Sacd) UnpackNextPaymentId(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // PackOnTransfer is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xe81e9b64.
+// the contract method with ID 0xe81e9b64.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function onTransfer(address asset, uint256 tokenId) returns()
 func (sacd *Sacd) PackOnTransfer(asset common.Address, tokenId *big.Int) []byte {
@@ -452,8 +613,18 @@ func (sacd *Sacd) PackOnTransfer(asset common.Address, tokenId *big.Int) []byte 
 	return enc
 }
 
+// TryPackOnTransfer is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xe81e9b64.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function onTransfer(address asset, uint256 tokenId) returns()
+func (sacd *Sacd) TryPackOnTransfer(asset common.Address, tokenId *big.Int) ([]byte, error) {
+	return sacd.abi.Pack("onTransfer", asset, tokenId)
+}
+
 // PackPaymentRecords is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x51f88a65.
+// the contract method with ID 0x51f88a65.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function paymentRecords(address asset, address grantee, address grantor, uint256 paymentId) view returns((uint256,uint64,bytes3,string) paymentRecord)
 func (sacd *Sacd) PackPaymentRecords(asset common.Address, grantee common.Address, grantor common.Address, paymentId *big.Int) []byte {
@@ -462,6 +633,15 @@ func (sacd *Sacd) PackPaymentRecords(asset common.Address, grantee common.Addres
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackPaymentRecords is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x51f88a65.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function paymentRecords(address asset, address grantee, address grantor, uint256 paymentId) view returns((uint256,uint64,bytes3,string) paymentRecord)
+func (sacd *Sacd) TryPackPaymentRecords(asset common.Address, grantee common.Address, grantor common.Address, paymentId *big.Int) ([]byte, error) {
+	return sacd.abi.Pack("paymentRecords", asset, grantee, grantor, paymentId)
 }
 
 // UnpackPaymentRecords is the Go binding that unpacks the parameters returned
@@ -474,11 +654,12 @@ func (sacd *Sacd) UnpackPaymentRecords(data []byte) (ISacdPaymentRecord, error) 
 		return *new(ISacdPaymentRecord), err
 	}
 	out0 := *abi.ConvertType(out[0], new(ISacdPaymentRecord)).(*ISacdPaymentRecord)
-	return out0, err
+	return out0, nil
 }
 
 // PackPermissionRecords is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x15e7d96b.
+// the contract method with ID 0x15e7d96b.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function permissionRecords(address asset, uint256 tokenId, uint256 version, address grantee) view returns((uint256,uint256,string,uint256) permissionRecord)
 func (sacd *Sacd) PackPermissionRecords(asset common.Address, tokenId *big.Int, version *big.Int, grantee common.Address) []byte {
@@ -487,6 +668,15 @@ func (sacd *Sacd) PackPermissionRecords(asset common.Address, tokenId *big.Int, 
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackPermissionRecords is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x15e7d96b.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function permissionRecords(address asset, uint256 tokenId, uint256 version, address grantee) view returns((uint256,uint256,string,uint256) permissionRecord)
+func (sacd *Sacd) TryPackPermissionRecords(asset common.Address, tokenId *big.Int, version *big.Int, grantee common.Address) ([]byte, error) {
+	return sacd.abi.Pack("permissionRecords", asset, tokenId, version, grantee)
 }
 
 // UnpackPermissionRecords is the Go binding that unpacks the parameters returned
@@ -499,11 +689,12 @@ func (sacd *Sacd) UnpackPermissionRecords(data []byte) (ISacdPermissionRecord, e
 		return *new(ISacdPermissionRecord), err
 	}
 	out0 := *abi.ConvertType(out[0], new(ISacdPermissionRecord)).(*ISacdPermissionRecord)
-	return out0, err
+	return out0, nil
 }
 
 // PackProxiableUUID is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x52d1902d.
+// the contract method with ID 0x52d1902d.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function proxiableUUID() view returns(bytes32)
 func (sacd *Sacd) PackProxiableUUID() []byte {
@@ -512,6 +703,15 @@ func (sacd *Sacd) PackProxiableUUID() []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackProxiableUUID is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x52d1902d.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (sacd *Sacd) TryPackProxiableUUID() ([]byte, error) {
+	return sacd.abi.Pack("proxiableUUID")
 }
 
 // UnpackProxiableUUID is the Go binding that unpacks the parameters returned
@@ -524,11 +724,56 @@ func (sacd *Sacd) UnpackProxiableUUID(data []byte) ([32]byte, error) {
 		return *new([32]byte), err
 	}
 	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
-	return out0, err
+	return out0, nil
+}
+
+// PackRenounceAccountPermissions is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x16d78242.  This method will panic if any
+// invalid/nil inputs are passed.
+//
+// Solidity: function renounceAccountPermissions(address grantor) returns()
+func (sacd *Sacd) PackRenounceAccountPermissions(grantor common.Address) []byte {
+	enc, err := sacd.abi.Pack("renounceAccountPermissions", grantor)
+	if err != nil {
+		panic(err)
+	}
+	return enc
+}
+
+// TryPackRenounceAccountPermissions is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x16d78242.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function renounceAccountPermissions(address grantor) returns()
+func (sacd *Sacd) TryPackRenounceAccountPermissions(grantor common.Address) ([]byte, error) {
+	return sacd.abi.Pack("renounceAccountPermissions", grantor)
+}
+
+// PackRenouncePermissions is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x290a7e7e.  This method will panic if any
+// invalid/nil inputs are passed.
+//
+// Solidity: function renouncePermissions(address asset, uint256 tokenId) returns()
+func (sacd *Sacd) PackRenouncePermissions(asset common.Address, tokenId *big.Int) []byte {
+	enc, err := sacd.abi.Pack("renouncePermissions", asset, tokenId)
+	if err != nil {
+		panic(err)
+	}
+	return enc
+}
+
+// TryPackRenouncePermissions is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x290a7e7e.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function renouncePermissions(address asset, uint256 tokenId) returns()
+func (sacd *Sacd) TryPackRenouncePermissions(asset common.Address, tokenId *big.Int) ([]byte, error) {
+	return sacd.abi.Pack("renouncePermissions", asset, tokenId)
 }
 
 // PackRenounceRole is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x36568abe.
+// the contract method with ID 0x36568abe.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
 func (sacd *Sacd) PackRenounceRole(role [32]byte, callerConfirmation common.Address) []byte {
@@ -539,8 +784,18 @@ func (sacd *Sacd) PackRenounceRole(role [32]byte, callerConfirmation common.Addr
 	return enc
 }
 
+// TryPackRenounceRole is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x36568abe.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (sacd *Sacd) TryPackRenounceRole(role [32]byte, callerConfirmation common.Address) ([]byte, error) {
+	return sacd.abi.Pack("renounceRole", role, callerConfirmation)
+}
+
 // PackRevokeRole is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xd547741f.
+// the contract method with ID 0xd547741f.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function revokeRole(bytes32 role, address account) returns()
 func (sacd *Sacd) PackRevokeRole(role [32]byte, account common.Address) []byte {
@@ -551,8 +806,18 @@ func (sacd *Sacd) PackRevokeRole(role [32]byte, account common.Address) []byte {
 	return enc
 }
 
+// TryPackRevokeRole is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xd547741f.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (sacd *Sacd) TryPackRevokeRole(role [32]byte, account common.Address) ([]byte, error) {
+	return sacd.abi.Pack("revokeRole", role, account)
+}
+
 // PackSetAccountPermissions is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x271c6d39.
+// the contract method with ID 0x271c6d39.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function setAccountPermissions(address grantee, uint256 permissions, uint256 expiration, uint256 templateId, string source) returns()
 func (sacd *Sacd) PackSetAccountPermissions(grantee common.Address, permissions *big.Int, expiration *big.Int, templateId *big.Int, source string) []byte {
@@ -563,8 +828,18 @@ func (sacd *Sacd) PackSetAccountPermissions(grantee common.Address, permissions 
 	return enc
 }
 
+// TryPackSetAccountPermissions is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x271c6d39.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function setAccountPermissions(address grantee, uint256 permissions, uint256 expiration, uint256 templateId, string source) returns()
+func (sacd *Sacd) TryPackSetAccountPermissions(grantee common.Address, permissions *big.Int, expiration *big.Int, templateId *big.Int, source string) ([]byte, error) {
+	return sacd.abi.Pack("setAccountPermissions", grantee, permissions, expiration, templateId, source)
+}
+
 // PackSetPayment is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xa23cac39.
+// the contract method with ID 0xa23cac39.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function setPayment(address asset, address grantor, uint256 amount, uint64 expiration, bytes3 currency, string source) returns()
 func (sacd *Sacd) PackSetPayment(asset common.Address, grantor common.Address, amount *big.Int, expiration uint64, currency [3]byte, source string) []byte {
@@ -575,8 +850,18 @@ func (sacd *Sacd) PackSetPayment(asset common.Address, grantor common.Address, a
 	return enc
 }
 
+// TryPackSetPayment is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xa23cac39.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function setPayment(address asset, address grantor, uint256 amount, uint64 expiration, bytes3 currency, string source) returns()
+func (sacd *Sacd) TryPackSetPayment(asset common.Address, grantor common.Address, amount *big.Int, expiration uint64, currency [3]byte, source string) ([]byte, error) {
+	return sacd.abi.Pack("setPayment", asset, grantor, amount, expiration, currency, source)
+}
+
 // PackSetPermissions is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x02e690e4.
+// the contract method with ID 0x02e690e4.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function setPermissions(address asset, uint256 tokenId, address grantee, uint256 permissions, uint256 expiration, uint256 templateId, string source) returns()
 func (sacd *Sacd) PackSetPermissions(asset common.Address, tokenId *big.Int, grantee common.Address, permissions *big.Int, expiration *big.Int, templateId *big.Int, source string) []byte {
@@ -587,8 +872,18 @@ func (sacd *Sacd) PackSetPermissions(asset common.Address, tokenId *big.Int, gra
 	return enc
 }
 
+// TryPackSetPermissions is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x02e690e4.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function setPermissions(address asset, uint256 tokenId, address grantee, uint256 permissions, uint256 expiration, uint256 templateId, string source) returns()
+func (sacd *Sacd) TryPackSetPermissions(asset common.Address, tokenId *big.Int, grantee common.Address, permissions *big.Int, expiration *big.Int, templateId *big.Int, source string) ([]byte, error) {
+	return sacd.abi.Pack("setPermissions", asset, tokenId, grantee, permissions, expiration, templateId, source)
+}
+
 // PackSetPermissions0 is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xe711f339.
+// the contract method with ID 0xe711f339.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function setPermissions(address asset, uint256 tokenId, address grantee, uint256 permissions, uint256 expiration, string source) returns()
 func (sacd *Sacd) PackSetPermissions0(asset common.Address, tokenId *big.Int, grantee common.Address, permissions *big.Int, expiration *big.Int, source string) []byte {
@@ -599,8 +894,18 @@ func (sacd *Sacd) PackSetPermissions0(asset common.Address, tokenId *big.Int, gr
 	return enc
 }
 
+// TryPackSetPermissions0 is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xe711f339.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function setPermissions(address asset, uint256 tokenId, address grantee, uint256 permissions, uint256 expiration, string source) returns()
+func (sacd *Sacd) TryPackSetPermissions0(asset common.Address, tokenId *big.Int, grantee common.Address, permissions *big.Int, expiration *big.Int, source string) ([]byte, error) {
+	return sacd.abi.Pack("setPermissions0", asset, tokenId, grantee, permissions, expiration, source)
+}
+
 // PackSetTemplateContract is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x670983fa.
+// the contract method with ID 0x670983fa.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function setTemplateContract(address templateContractAddress) returns()
 func (sacd *Sacd) PackSetTemplateContract(templateContractAddress common.Address) []byte {
@@ -611,8 +916,18 @@ func (sacd *Sacd) PackSetTemplateContract(templateContractAddress common.Address
 	return enc
 }
 
+// TryPackSetTemplateContract is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x670983fa.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function setTemplateContract(address templateContractAddress) returns()
+func (sacd *Sacd) TryPackSetTemplateContract(templateContractAddress common.Address) ([]byte, error) {
+	return sacd.abi.Pack("setTemplateContract", templateContractAddress)
+}
+
 // PackSupportsInterface is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x01ffc9a7.
+// the contract method with ID 0x01ffc9a7.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
 func (sacd *Sacd) PackSupportsInterface(interfaceId [4]byte) []byte {
@@ -621,6 +936,15 @@ func (sacd *Sacd) PackSupportsInterface(interfaceId [4]byte) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackSupportsInterface is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x01ffc9a7.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (sacd *Sacd) TryPackSupportsInterface(interfaceId [4]byte) ([]byte, error) {
+	return sacd.abi.Pack("supportsInterface", interfaceId)
 }
 
 // UnpackSupportsInterface is the Go binding that unpacks the parameters returned
@@ -633,11 +957,12 @@ func (sacd *Sacd) UnpackSupportsInterface(data []byte) (bool, error) {
 		return *new(bool), err
 	}
 	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
-	return out0, err
+	return out0, nil
 }
 
 // PackTemplateContract is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x72be06d8.
+// the contract method with ID 0x72be06d8.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function templateContract() view returns(address template_)
 func (sacd *Sacd) PackTemplateContract() []byte {
@@ -646,6 +971,15 @@ func (sacd *Sacd) PackTemplateContract() []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackTemplateContract is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x72be06d8.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function templateContract() view returns(address template_)
+func (sacd *Sacd) TryPackTemplateContract() ([]byte, error) {
+	return sacd.abi.Pack("templateContract")
 }
 
 // UnpackTemplateContract is the Go binding that unpacks the parameters returned
@@ -658,11 +992,12 @@ func (sacd *Sacd) UnpackTemplateContract(data []byte) (common.Address, error) {
 		return *new(common.Address), err
 	}
 	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
-	return out0, err
+	return out0, nil
 }
 
 // PackTokenIdToVersion is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xeba57928.
+// the contract method with ID 0xeba57928.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function tokenIdToVersion(address asset, uint256 tokenId) view returns(uint256 version)
 func (sacd *Sacd) PackTokenIdToVersion(asset common.Address, tokenId *big.Int) []byte {
@@ -671,6 +1006,15 @@ func (sacd *Sacd) PackTokenIdToVersion(asset common.Address, tokenId *big.Int) [
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackTokenIdToVersion is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xeba57928.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function tokenIdToVersion(address asset, uint256 tokenId) view returns(uint256 version)
+func (sacd *Sacd) TryPackTokenIdToVersion(asset common.Address, tokenId *big.Int) ([]byte, error) {
+	return sacd.abi.Pack("tokenIdToVersion", asset, tokenId)
 }
 
 // UnpackTokenIdToVersion is the Go binding that unpacks the parameters returned
@@ -683,11 +1027,12 @@ func (sacd *Sacd) UnpackTokenIdToVersion(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // PackUpgradeToAndCall is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x4f1ef286.
+// the contract method with ID 0x4f1ef286.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
 func (sacd *Sacd) PackUpgradeToAndCall(newImplementation common.Address, data []byte) []byte {
@@ -696,6 +1041,15 @@ func (sacd *Sacd) PackUpgradeToAndCall(newImplementation common.Address, data []
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackUpgradeToAndCall is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x4f1ef286.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (sacd *Sacd) TryPackUpgradeToAndCall(newImplementation common.Address, data []byte) ([]byte, error) {
+	return sacd.abi.Pack("upgradeToAndCall", newImplementation, data)
 }
 
 // SacdInitialized represents a Initialized event raised by the Sacd contract.
@@ -717,7 +1071,7 @@ func (SacdInitialized) ContractEventName() string {
 // Solidity: event Initialized(uint64 version)
 func (sacd *Sacd) UnpackInitializedEvent(log *types.Log) (*SacdInitialized, error) {
 	event := "Initialized"
-	if log.Topics[0] != sacd.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != sacd.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(SacdInitialized)
@@ -763,10 +1117,53 @@ func (SacdPaymentSet) ContractEventName() string {
 // Solidity: event PaymentSet(address indexed asset, address indexed grantee, address indexed grantor, uint256 amount, uint256 expiration, string source)
 func (sacd *Sacd) UnpackPaymentSetEvent(log *types.Log) (*SacdPaymentSet, error) {
 	event := "PaymentSet"
-	if log.Topics[0] != sacd.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != sacd.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(SacdPaymentSet)
+	if len(log.Data) > 0 {
+		if err := sacd.abi.UnpackIntoInterface(out, event, log.Data); err != nil {
+			return nil, err
+		}
+	}
+	var indexed abi.Arguments
+	for _, arg := range sacd.abi.Events[event].Inputs {
+		if arg.Indexed {
+			indexed = append(indexed, arg)
+		}
+	}
+	if err := abi.ParseTopics(out, indexed, log.Topics[1:]); err != nil {
+		return nil, err
+	}
+	out.Raw = log
+	return out, nil
+}
+
+// SacdPermissionsRenounced represents a PermissionsRenounced event raised by the Sacd contract.
+type SacdPermissionsRenounced struct {
+	Asset   common.Address
+	TokenId *big.Int
+	Grantee common.Address
+	Raw     *types.Log // Blockchain specific contextual infos
+}
+
+const SacdPermissionsRenouncedEventName = "PermissionsRenounced"
+
+// ContractEventName returns the user-defined event name.
+func (SacdPermissionsRenounced) ContractEventName() string {
+	return SacdPermissionsRenouncedEventName
+}
+
+// UnpackPermissionsRenouncedEvent is the Go binding that unpacks the event data emitted
+// by contract.
+//
+// Solidity: event PermissionsRenounced(address indexed asset, uint256 indexed tokenId, address indexed grantee)
+func (sacd *Sacd) UnpackPermissionsRenouncedEvent(log *types.Log) (*SacdPermissionsRenounced, error) {
+	event := "PermissionsRenounced"
+	if len(log.Topics) == 0 || log.Topics[0] != sacd.abi.Events[event].ID {
+		return nil, errors.New("event signature mismatch")
+	}
+	out := new(SacdPermissionsRenounced)
 	if len(log.Data) > 0 {
 		if err := sacd.abi.UnpackIntoInterface(out, event, log.Data); err != nil {
 			return nil, err
@@ -810,7 +1207,7 @@ func (SacdPermissionsSet) ContractEventName() string {
 // Solidity: event PermissionsSet(address indexed asset, uint256 indexed tokenId, uint256 permissions, address indexed grantee, uint256 expiration, uint256 templateId, string source)
 func (sacd *Sacd) UnpackPermissionsSetEvent(log *types.Log) (*SacdPermissionsSet, error) {
 	event := "PermissionsSet"
-	if log.Topics[0] != sacd.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != sacd.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(SacdPermissionsSet)
@@ -853,7 +1250,7 @@ func (SacdRoleAdminChanged) ContractEventName() string {
 // Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
 func (sacd *Sacd) UnpackRoleAdminChangedEvent(log *types.Log) (*SacdRoleAdminChanged, error) {
 	event := "RoleAdminChanged"
-	if log.Topics[0] != sacd.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != sacd.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(SacdRoleAdminChanged)
@@ -896,7 +1293,7 @@ func (SacdRoleGranted) ContractEventName() string {
 // Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
 func (sacd *Sacd) UnpackRoleGrantedEvent(log *types.Log) (*SacdRoleGranted, error) {
 	event := "RoleGranted"
-	if log.Topics[0] != sacd.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != sacd.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(SacdRoleGranted)
@@ -939,7 +1336,7 @@ func (SacdRoleRevoked) ContractEventName() string {
 // Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
 func (sacd *Sacd) UnpackRoleRevokedEvent(log *types.Log) (*SacdRoleRevoked, error) {
 	event := "RoleRevoked"
-	if log.Topics[0] != sacd.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != sacd.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(SacdRoleRevoked)
@@ -980,7 +1377,7 @@ func (SacdUpgraded) ContractEventName() string {
 // Solidity: event Upgraded(address indexed implementation)
 func (sacd *Sacd) UnpackUpgradedEvent(log *types.Log) (*SacdUpgraded, error) {
 	event := "Upgraded"
-	if log.Topics[0] != sacd.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != sacd.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(SacdUpgraded)

--- a/bindings/template/template.go
+++ b/bindings/template/template.go
@@ -59,7 +59,8 @@ func (c *Template) Instance(backend bind.ContractBackend, addr common.Address) *
 }
 
 // PackDEFAULTADMINROLE is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xa217fddf.
+// the contract method with ID 0xa217fddf.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
 func (template *Template) PackDEFAULTADMINROLE() []byte {
@@ -68,6 +69,15 @@ func (template *Template) PackDEFAULTADMINROLE() []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackDEFAULTADMINROLE is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xa217fddf.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (template *Template) TryPackDEFAULTADMINROLE() ([]byte, error) {
+	return template.abi.Pack("DEFAULT_ADMIN_ROLE")
 }
 
 // UnpackDEFAULTADMINROLE is the Go binding that unpacks the parameters returned
@@ -80,11 +90,12 @@ func (template *Template) UnpackDEFAULTADMINROLE(data []byte) ([32]byte, error) 
 		return *new([32]byte), err
 	}
 	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
-	return out0, err
+	return out0, nil
 }
 
 // PackUPGRADEINTERFACEVERSION is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xad3cb1cc.
+// the contract method with ID 0xad3cb1cc.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
 func (template *Template) PackUPGRADEINTERFACEVERSION() []byte {
@@ -93,6 +104,15 @@ func (template *Template) PackUPGRADEINTERFACEVERSION() []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackUPGRADEINTERFACEVERSION is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xad3cb1cc.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (template *Template) TryPackUPGRADEINTERFACEVERSION() ([]byte, error) {
+	return template.abi.Pack("UPGRADE_INTERFACE_VERSION")
 }
 
 // UnpackUPGRADEINTERFACEVERSION is the Go binding that unpacks the parameters returned
@@ -105,11 +125,12 @@ func (template *Template) UnpackUPGRADEINTERFACEVERSION(data []byte) (string, er
 		return *new(string), err
 	}
 	out0 := *abi.ConvertType(out[0], new(string)).(*string)
-	return out0, err
+	return out0, nil
 }
 
 // PackActivateTemplate is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x9e060763.
+// the contract method with ID 0x9e060763.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function activateTemplate(uint256 templateId) returns()
 func (template *Template) PackActivateTemplate(templateId *big.Int) []byte {
@@ -120,8 +141,18 @@ func (template *Template) PackActivateTemplate(templateId *big.Int) []byte {
 	return enc
 }
 
+// TryPackActivateTemplate is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x9e060763.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function activateTemplate(uint256 templateId) returns()
+func (template *Template) TryPackActivateTemplate(templateId *big.Int) ([]byte, error) {
+	return template.abi.Pack("activateTemplate", templateId)
+}
+
 // PackApprove is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x095ea7b3.
+// the contract method with ID 0x095ea7b3.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function approve(address to, uint256 tokenId) returns()
 func (template *Template) PackApprove(to common.Address, tokenId *big.Int) []byte {
@@ -132,8 +163,18 @@ func (template *Template) PackApprove(to common.Address, tokenId *big.Int) []byt
 	return enc
 }
 
+// TryPackApprove is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x095ea7b3.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function approve(address to, uint256 tokenId) returns()
+func (template *Template) TryPackApprove(to common.Address, tokenId *big.Int) ([]byte, error) {
+	return template.abi.Pack("approve", to, tokenId)
+}
+
 // PackBalanceOf is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x70a08231.
+// the contract method with ID 0x70a08231.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function balanceOf(address owner) view returns(uint256)
 func (template *Template) PackBalanceOf(owner common.Address) []byte {
@@ -142,6 +183,15 @@ func (template *Template) PackBalanceOf(owner common.Address) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackBalanceOf is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x70a08231.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function balanceOf(address owner) view returns(uint256)
+func (template *Template) TryPackBalanceOf(owner common.Address) ([]byte, error) {
+	return template.abi.Pack("balanceOf", owner)
 }
 
 // UnpackBalanceOf is the Go binding that unpacks the parameters returned
@@ -154,11 +204,12 @@ func (template *Template) UnpackBalanceOf(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // PackBaseURI is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x6c0360eb.
+// the contract method with ID 0x6c0360eb.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function baseURI() view returns(string)
 func (template *Template) PackBaseURI() []byte {
@@ -167,6 +218,15 @@ func (template *Template) PackBaseURI() []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackBaseURI is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x6c0360eb.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function baseURI() view returns(string)
+func (template *Template) TryPackBaseURI() ([]byte, error) {
+	return template.abi.Pack("baseURI")
 }
 
 // UnpackBaseURI is the Go binding that unpacks the parameters returned
@@ -179,11 +239,12 @@ func (template *Template) UnpackBaseURI(data []byte) (string, error) {
 		return *new(string), err
 	}
 	out0 := *abi.ConvertType(out[0], new(string)).(*string)
-	return out0, err
+	return out0, nil
 }
 
 // PackCreateTemplate is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x060ff5b9.
+// the contract method with ID 0x060ff5b9.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function createTemplate(address owner, address asset, uint256 permissions, string cid) returns(uint256 templateId)
 func (template *Template) PackCreateTemplate(owner common.Address, asset common.Address, permissions *big.Int, cid string) []byte {
@@ -192,6 +253,15 @@ func (template *Template) PackCreateTemplate(owner common.Address, asset common.
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackCreateTemplate is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x060ff5b9.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function createTemplate(address owner, address asset, uint256 permissions, string cid) returns(uint256 templateId)
+func (template *Template) TryPackCreateTemplate(owner common.Address, asset common.Address, permissions *big.Int, cid string) ([]byte, error) {
+	return template.abi.Pack("createTemplate", owner, asset, permissions, cid)
 }
 
 // UnpackCreateTemplate is the Go binding that unpacks the parameters returned
@@ -204,11 +274,12 @@ func (template *Template) UnpackCreateTemplate(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // PackDeactivateTemplate is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x1d1a689e.
+// the contract method with ID 0x1d1a689e.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function deactivateTemplate(uint256 templateId) returns()
 func (template *Template) PackDeactivateTemplate(templateId *big.Int) []byte {
@@ -219,8 +290,18 @@ func (template *Template) PackDeactivateTemplate(templateId *big.Int) []byte {
 	return enc
 }
 
+// TryPackDeactivateTemplate is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x1d1a689e.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function deactivateTemplate(uint256 templateId) returns()
+func (template *Template) TryPackDeactivateTemplate(templateId *big.Int) ([]byte, error) {
+	return template.abi.Pack("deactivateTemplate", templateId)
+}
+
 // PackGetApproved is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x081812fc.
+// the contract method with ID 0x081812fc.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function getApproved(uint256 tokenId) view returns(address)
 func (template *Template) PackGetApproved(tokenId *big.Int) []byte {
@@ -229,6 +310,15 @@ func (template *Template) PackGetApproved(tokenId *big.Int) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackGetApproved is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x081812fc.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function getApproved(uint256 tokenId) view returns(address)
+func (template *Template) TryPackGetApproved(tokenId *big.Int) ([]byte, error) {
+	return template.abi.Pack("getApproved", tokenId)
 }
 
 // UnpackGetApproved is the Go binding that unpacks the parameters returned
@@ -241,11 +331,12 @@ func (template *Template) UnpackGetApproved(data []byte) (common.Address, error)
 		return *new(common.Address), err
 	}
 	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
-	return out0, err
+	return out0, nil
 }
 
 // PackGetRoleAdmin is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x248a9ca3.
+// the contract method with ID 0x248a9ca3.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
 func (template *Template) PackGetRoleAdmin(role [32]byte) []byte {
@@ -254,6 +345,15 @@ func (template *Template) PackGetRoleAdmin(role [32]byte) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackGetRoleAdmin is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x248a9ca3.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (template *Template) TryPackGetRoleAdmin(role [32]byte) ([]byte, error) {
+	return template.abi.Pack("getRoleAdmin", role)
 }
 
 // UnpackGetRoleAdmin is the Go binding that unpacks the parameters returned
@@ -266,11 +366,12 @@ func (template *Template) UnpackGetRoleAdmin(data []byte) ([32]byte, error) {
 		return *new([32]byte), err
 	}
 	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
-	return out0, err
+	return out0, nil
 }
 
 // PackGetTemplate is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x31543cf4.
+// the contract method with ID 0x31543cf4.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function getTemplate(uint256 templateId) view returns((address,uint256,string,bool) template)
 func (template *Template) PackGetTemplate(templateId *big.Int) []byte {
@@ -279,6 +380,15 @@ func (template *Template) PackGetTemplate(templateId *big.Int) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackGetTemplate is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x31543cf4.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function getTemplate(uint256 templateId) view returns((address,uint256,string,bool) template)
+func (template *Template) TryPackGetTemplate(templateId *big.Int) ([]byte, error) {
+	return template.abi.Pack("getTemplate", templateId)
 }
 
 // UnpackGetTemplate is the Go binding that unpacks the parameters returned
@@ -291,11 +401,12 @@ func (template *Template) UnpackGetTemplate(data []byte) (ITemplateTemplateData,
 		return *new(ITemplateTemplateData), err
 	}
 	out0 := *abi.ConvertType(out[0], new(ITemplateTemplateData)).(*ITemplateTemplateData)
-	return out0, err
+	return out0, nil
 }
 
 // PackGrantRole is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x2f2ff15d.
+// the contract method with ID 0x2f2ff15d.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function grantRole(bytes32 role, address account) returns()
 func (template *Template) PackGrantRole(role [32]byte, account common.Address) []byte {
@@ -306,8 +417,18 @@ func (template *Template) PackGrantRole(role [32]byte, account common.Address) [
 	return enc
 }
 
+// TryPackGrantRole is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x2f2ff15d.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (template *Template) TryPackGrantRole(role [32]byte, account common.Address) ([]byte, error) {
+	return template.abi.Pack("grantRole", role, account)
+}
+
 // PackHasRole is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x91d14854.
+// the contract method with ID 0x91d14854.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function hasRole(bytes32 role, address account) view returns(bool)
 func (template *Template) PackHasRole(role [32]byte, account common.Address) []byte {
@@ -316,6 +437,15 @@ func (template *Template) PackHasRole(role [32]byte, account common.Address) []b
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackHasRole is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x91d14854.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (template *Template) TryPackHasRole(role [32]byte, account common.Address) ([]byte, error) {
+	return template.abi.Pack("hasRole", role, account)
 }
 
 // UnpackHasRole is the Go binding that unpacks the parameters returned
@@ -328,11 +458,12 @@ func (template *Template) UnpackHasRole(data []byte) (bool, error) {
 		return *new(bool), err
 	}
 	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
-	return out0, err
+	return out0, nil
 }
 
 // PackInitialize is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xf399e22e.
+// the contract method with ID 0xf399e22e.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function initialize(address admin, string baseURI_) returns()
 func (template *Template) PackInitialize(admin common.Address, baseURI string) []byte {
@@ -343,8 +474,18 @@ func (template *Template) PackInitialize(admin common.Address, baseURI string) [
 	return enc
 }
 
+// TryPackInitialize is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xf399e22e.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function initialize(address admin, string baseURI_) returns()
+func (template *Template) TryPackInitialize(admin common.Address, baseURI string) ([]byte, error) {
+	return template.abi.Pack("initialize", admin, baseURI)
+}
+
 // PackIsApprovedForAll is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xe985e9c5.
+// the contract method with ID 0xe985e9c5.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function isApprovedForAll(address owner, address operator) view returns(bool)
 func (template *Template) PackIsApprovedForAll(owner common.Address, operator common.Address) []byte {
@@ -353,6 +494,15 @@ func (template *Template) PackIsApprovedForAll(owner common.Address, operator co
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackIsApprovedForAll is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xe985e9c5.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function isApprovedForAll(address owner, address operator) view returns(bool)
+func (template *Template) TryPackIsApprovedForAll(owner common.Address, operator common.Address) ([]byte, error) {
+	return template.abi.Pack("isApprovedForAll", owner, operator)
 }
 
 // UnpackIsApprovedForAll is the Go binding that unpacks the parameters returned
@@ -365,11 +515,12 @@ func (template *Template) UnpackIsApprovedForAll(data []byte) (bool, error) {
 		return *new(bool), err
 	}
 	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
-	return out0, err
+	return out0, nil
 }
 
 // PackIsTemplateActive is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xe0a0d933.
+// the contract method with ID 0xe0a0d933.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function isTemplateActive(uint256 templateId) view returns(bool isActive)
 func (template *Template) PackIsTemplateActive(templateId *big.Int) []byte {
@@ -378,6 +529,15 @@ func (template *Template) PackIsTemplateActive(templateId *big.Int) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackIsTemplateActive is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xe0a0d933.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function isTemplateActive(uint256 templateId) view returns(bool isActive)
+func (template *Template) TryPackIsTemplateActive(templateId *big.Int) ([]byte, error) {
+	return template.abi.Pack("isTemplateActive", templateId)
 }
 
 // UnpackIsTemplateActive is the Go binding that unpacks the parameters returned
@@ -390,11 +550,12 @@ func (template *Template) UnpackIsTemplateActive(data []byte) (bool, error) {
 		return *new(bool), err
 	}
 	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
-	return out0, err
+	return out0, nil
 }
 
 // PackName is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x06fdde03.
+// the contract method with ID 0x06fdde03.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function name() view returns(string)
 func (template *Template) PackName() []byte {
@@ -403,6 +564,15 @@ func (template *Template) PackName() []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackName is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x06fdde03.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function name() view returns(string)
+func (template *Template) TryPackName() ([]byte, error) {
+	return template.abi.Pack("name")
 }
 
 // UnpackName is the Go binding that unpacks the parameters returned
@@ -415,11 +585,12 @@ func (template *Template) UnpackName(data []byte) (string, error) {
 		return *new(string), err
 	}
 	out0 := *abi.ConvertType(out[0], new(string)).(*string)
-	return out0, err
+	return out0, nil
 }
 
 // PackOwnerOf is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x6352211e.
+// the contract method with ID 0x6352211e.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function ownerOf(uint256 tokenId) view returns(address)
 func (template *Template) PackOwnerOf(tokenId *big.Int) []byte {
@@ -428,6 +599,15 @@ func (template *Template) PackOwnerOf(tokenId *big.Int) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackOwnerOf is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x6352211e.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function ownerOf(uint256 tokenId) view returns(address)
+func (template *Template) TryPackOwnerOf(tokenId *big.Int) ([]byte, error) {
+	return template.abi.Pack("ownerOf", tokenId)
 }
 
 // UnpackOwnerOf is the Go binding that unpacks the parameters returned
@@ -440,11 +620,12 @@ func (template *Template) UnpackOwnerOf(data []byte) (common.Address, error) {
 		return *new(common.Address), err
 	}
 	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
-	return out0, err
+	return out0, nil
 }
 
 // PackProxiableUUID is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x52d1902d.
+// the contract method with ID 0x52d1902d.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function proxiableUUID() view returns(bytes32)
 func (template *Template) PackProxiableUUID() []byte {
@@ -453,6 +634,15 @@ func (template *Template) PackProxiableUUID() []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackProxiableUUID is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x52d1902d.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (template *Template) TryPackProxiableUUID() ([]byte, error) {
+	return template.abi.Pack("proxiableUUID")
 }
 
 // UnpackProxiableUUID is the Go binding that unpacks the parameters returned
@@ -465,11 +655,12 @@ func (template *Template) UnpackProxiableUUID(data []byte) ([32]byte, error) {
 		return *new([32]byte), err
 	}
 	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
-	return out0, err
+	return out0, nil
 }
 
 // PackRenounceRole is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x36568abe.
+// the contract method with ID 0x36568abe.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
 func (template *Template) PackRenounceRole(role [32]byte, callerConfirmation common.Address) []byte {
@@ -480,8 +671,18 @@ func (template *Template) PackRenounceRole(role [32]byte, callerConfirmation com
 	return enc
 }
 
+// TryPackRenounceRole is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x36568abe.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (template *Template) TryPackRenounceRole(role [32]byte, callerConfirmation common.Address) ([]byte, error) {
+	return template.abi.Pack("renounceRole", role, callerConfirmation)
+}
+
 // PackRevokeRole is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xd547741f.
+// the contract method with ID 0xd547741f.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function revokeRole(bytes32 role, address account) returns()
 func (template *Template) PackRevokeRole(role [32]byte, account common.Address) []byte {
@@ -492,8 +693,18 @@ func (template *Template) PackRevokeRole(role [32]byte, account common.Address) 
 	return enc
 }
 
+// TryPackRevokeRole is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xd547741f.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (template *Template) TryPackRevokeRole(role [32]byte, account common.Address) ([]byte, error) {
+	return template.abi.Pack("revokeRole", role, account)
+}
+
 // PackSafeTransferFrom is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x42842e0e.
+// the contract method with ID 0x42842e0e.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function safeTransferFrom(address from, address to, uint256 tokenId) returns()
 func (template *Template) PackSafeTransferFrom(from common.Address, to common.Address, tokenId *big.Int) []byte {
@@ -504,8 +715,18 @@ func (template *Template) PackSafeTransferFrom(from common.Address, to common.Ad
 	return enc
 }
 
+// TryPackSafeTransferFrom is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x42842e0e.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function safeTransferFrom(address from, address to, uint256 tokenId) returns()
+func (template *Template) TryPackSafeTransferFrom(from common.Address, to common.Address, tokenId *big.Int) ([]byte, error) {
+	return template.abi.Pack("safeTransferFrom", from, to, tokenId)
+}
+
 // PackSafeTransferFrom0 is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xb88d4fde.
+// the contract method with ID 0xb88d4fde.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) returns()
 func (template *Template) PackSafeTransferFrom0(from common.Address, to common.Address, tokenId *big.Int, data []byte) []byte {
@@ -516,8 +737,18 @@ func (template *Template) PackSafeTransferFrom0(from common.Address, to common.A
 	return enc
 }
 
+// TryPackSafeTransferFrom0 is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xb88d4fde.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) returns()
+func (template *Template) TryPackSafeTransferFrom0(from common.Address, to common.Address, tokenId *big.Int, data []byte) ([]byte, error) {
+	return template.abi.Pack("safeTransferFrom0", from, to, tokenId, data)
+}
+
 // PackSetApprovalForAll is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xa22cb465.
+// the contract method with ID 0xa22cb465.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function setApprovalForAll(address operator, bool approved) returns()
 func (template *Template) PackSetApprovalForAll(operator common.Address, approved bool) []byte {
@@ -528,8 +759,18 @@ func (template *Template) PackSetApprovalForAll(operator common.Address, approve
 	return enc
 }
 
+// TryPackSetApprovalForAll is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xa22cb465.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function setApprovalForAll(address operator, bool approved) returns()
+func (template *Template) TryPackSetApprovalForAll(operator common.Address, approved bool) ([]byte, error) {
+	return template.abi.Pack("setApprovalForAll", operator, approved)
+}
+
 // PackSupportsInterface is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x01ffc9a7.
+// the contract method with ID 0x01ffc9a7.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
 func (template *Template) PackSupportsInterface(interfaceId [4]byte) []byte {
@@ -538,6 +779,15 @@ func (template *Template) PackSupportsInterface(interfaceId [4]byte) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackSupportsInterface is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x01ffc9a7.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (template *Template) TryPackSupportsInterface(interfaceId [4]byte) ([]byte, error) {
+	return template.abi.Pack("supportsInterface", interfaceId)
 }
 
 // UnpackSupportsInterface is the Go binding that unpacks the parameters returned
@@ -550,11 +800,12 @@ func (template *Template) UnpackSupportsInterface(data []byte) (bool, error) {
 		return *new(bool), err
 	}
 	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
-	return out0, err
+	return out0, nil
 }
 
 // PackSymbol is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x95d89b41.
+// the contract method with ID 0x95d89b41.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function symbol() view returns(string)
 func (template *Template) PackSymbol() []byte {
@@ -563,6 +814,15 @@ func (template *Template) PackSymbol() []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackSymbol is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x95d89b41.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function symbol() view returns(string)
+func (template *Template) TryPackSymbol() ([]byte, error) {
+	return template.abi.Pack("symbol")
 }
 
 // UnpackSymbol is the Go binding that unpacks the parameters returned
@@ -575,11 +835,12 @@ func (template *Template) UnpackSymbol(data []byte) (string, error) {
 		return *new(string), err
 	}
 	out0 := *abi.ConvertType(out[0], new(string)).(*string)
-	return out0, err
+	return out0, nil
 }
 
 // PackTemplates is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xbc525652.
+// the contract method with ID 0xbc525652.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function templates(uint256 templateId) view returns((address,uint256,string,bool) templateData)
 func (template *Template) PackTemplates(templateId *big.Int) []byte {
@@ -588,6 +849,15 @@ func (template *Template) PackTemplates(templateId *big.Int) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackTemplates is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xbc525652.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function templates(uint256 templateId) view returns((address,uint256,string,bool) templateData)
+func (template *Template) TryPackTemplates(templateId *big.Int) ([]byte, error) {
+	return template.abi.Pack("templates", templateId)
 }
 
 // UnpackTemplates is the Go binding that unpacks the parameters returned
@@ -600,11 +870,12 @@ func (template *Template) UnpackTemplates(data []byte) (ITemplateTemplateData, e
 		return *new(ITemplateTemplateData), err
 	}
 	out0 := *abi.ConvertType(out[0], new(ITemplateTemplateData)).(*ITemplateTemplateData)
-	return out0, err
+	return out0, nil
 }
 
 // PackTokenURI is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0xc87b56dd.
+// the contract method with ID 0xc87b56dd.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function tokenURI(uint256 tokenId) view returns(string)
 func (template *Template) PackTokenURI(tokenId *big.Int) []byte {
@@ -613,6 +884,15 @@ func (template *Template) PackTokenURI(tokenId *big.Int) []byte {
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackTokenURI is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0xc87b56dd.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function tokenURI(uint256 tokenId) view returns(string)
+func (template *Template) TryPackTokenURI(tokenId *big.Int) ([]byte, error) {
+	return template.abi.Pack("tokenURI", tokenId)
 }
 
 // UnpackTokenURI is the Go binding that unpacks the parameters returned
@@ -625,11 +905,12 @@ func (template *Template) UnpackTokenURI(data []byte) (string, error) {
 		return *new(string), err
 	}
 	out0 := *abi.ConvertType(out[0], new(string)).(*string)
-	return out0, err
+	return out0, nil
 }
 
 // PackTransferFrom is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x23b872dd.
+// the contract method with ID 0x23b872dd.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function transferFrom(address from, address to, uint256 tokenId) returns()
 func (template *Template) PackTransferFrom(from common.Address, to common.Address, tokenId *big.Int) []byte {
@@ -640,8 +921,18 @@ func (template *Template) PackTransferFrom(from common.Address, to common.Addres
 	return enc
 }
 
+// TryPackTransferFrom is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x23b872dd.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function transferFrom(address from, address to, uint256 tokenId) returns()
+func (template *Template) TryPackTransferFrom(from common.Address, to common.Address, tokenId *big.Int) ([]byte, error) {
+	return template.abi.Pack("transferFrom", from, to, tokenId)
+}
+
 // PackUpgradeToAndCall is the Go binding used to pack the parameters required for calling
-// the contract method with ID 0x4f1ef286.
+// the contract method with ID 0x4f1ef286.  This method will panic if any
+// invalid/nil inputs are passed.
 //
 // Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
 func (template *Template) PackUpgradeToAndCall(newImplementation common.Address, data []byte) []byte {
@@ -650,6 +941,15 @@ func (template *Template) PackUpgradeToAndCall(newImplementation common.Address,
 		panic(err)
 	}
 	return enc
+}
+
+// TryPackUpgradeToAndCall is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x4f1ef286.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (template *Template) TryPackUpgradeToAndCall(newImplementation common.Address, data []byte) ([]byte, error) {
+	return template.abi.Pack("upgradeToAndCall", newImplementation, data)
 }
 
 // TemplateApproval represents a Approval event raised by the Template contract.
@@ -673,7 +973,7 @@ func (TemplateApproval) ContractEventName() string {
 // Solidity: event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId)
 func (template *Template) UnpackApprovalEvent(log *types.Log) (*TemplateApproval, error) {
 	event := "Approval"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateApproval)
@@ -716,7 +1016,7 @@ func (TemplateApprovalForAll) ContractEventName() string {
 // Solidity: event ApprovalForAll(address indexed owner, address indexed operator, bool approved)
 func (template *Template) UnpackApprovalForAllEvent(log *types.Log) (*TemplateApprovalForAll, error) {
 	event := "ApprovalForAll"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateApprovalForAll)
@@ -757,7 +1057,7 @@ func (TemplateInitialized) ContractEventName() string {
 // Solidity: event Initialized(uint64 version)
 func (template *Template) UnpackInitializedEvent(log *types.Log) (*TemplateInitialized, error) {
 	event := "Initialized"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateInitialized)
@@ -800,7 +1100,7 @@ func (TemplateRoleAdminChanged) ContractEventName() string {
 // Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
 func (template *Template) UnpackRoleAdminChangedEvent(log *types.Log) (*TemplateRoleAdminChanged, error) {
 	event := "RoleAdminChanged"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateRoleAdminChanged)
@@ -843,7 +1143,7 @@ func (TemplateRoleGranted) ContractEventName() string {
 // Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
 func (template *Template) UnpackRoleGrantedEvent(log *types.Log) (*TemplateRoleGranted, error) {
 	event := "RoleGranted"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateRoleGranted)
@@ -886,7 +1186,7 @@ func (TemplateRoleRevoked) ContractEventName() string {
 // Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
 func (template *Template) UnpackRoleRevokedEvent(log *types.Log) (*TemplateRoleRevoked, error) {
 	event := "RoleRevoked"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateRoleRevoked)
@@ -927,7 +1227,7 @@ func (TemplateTemplateActivated) ContractEventName() string {
 // Solidity: event TemplateActivated(uint256 indexed templateId)
 func (template *Template) UnpackTemplateActivatedEvent(log *types.Log) (*TemplateTemplateActivated, error) {
 	event := "TemplateActivated"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateTemplateActivated)
@@ -972,7 +1272,7 @@ func (TemplateTemplateCreated) ContractEventName() string {
 // Solidity: event TemplateCreated(uint256 indexed templateId, address indexed creator, address indexed asset, uint256 permissions, string cid)
 func (template *Template) UnpackTemplateCreatedEvent(log *types.Log) (*TemplateTemplateCreated, error) {
 	event := "TemplateCreated"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateTemplateCreated)
@@ -1013,7 +1313,7 @@ func (TemplateTemplateDeactivated) ContractEventName() string {
 // Solidity: event TemplateDeactivated(uint256 indexed templateId)
 func (template *Template) UnpackTemplateDeactivatedEvent(log *types.Log) (*TemplateTemplateDeactivated, error) {
 	event := "TemplateDeactivated"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateTemplateDeactivated)
@@ -1056,7 +1356,7 @@ func (TemplateTransfer) ContractEventName() string {
 // Solidity: event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)
 func (template *Template) UnpackTransferEvent(log *types.Log) (*TemplateTransfer, error) {
 	event := "Transfer"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateTransfer)
@@ -1097,7 +1397,7 @@ func (TemplateUpgraded) ContractEventName() string {
 // Solidity: event Upgraded(address indexed implementation)
 func (template *Template) UnpackUpgradedEvent(log *types.Log) (*TemplateUpgraded, error) {
 	event := "Upgraded"
-	if log.Topics[0] != template.abi.Events[event].ID {
+	if len(log.Topics) == 0 || log.Topics[0] != template.abi.Events[event].ID {
 		return nil, errors.New("event signature mismatch")
 	}
 	out := new(TemplateUpgraded)

--- a/contracts/Sacd.sol
+++ b/contracts/Sacd.sol
@@ -146,6 +146,39 @@ contract Sacd is ISacd, Initializable, AccessControlUpgradeable, UUPSUpgradeable
   }
 
   /**
+   * @notice Allows a grantee to renounce their own asset-tied permission record
+   * @dev The caller (msg.sender) is the grantee. Clears the permission record at the
+   *      current token version. Emits PermissionsRenounced as a self-contained signal
+   *      that the grantee cleared the record. Does not emit PermissionsSet.
+   *      Always emits, even if no record exists, mirroring setPermissions' unconditional
+   *      emit semantics.
+   * @param asset The contract address of the ERC721
+   * @param tokenId Token ID associated with the permissions
+   */
+  function renouncePermissions(address asset, uint256 tokenId) external {
+    SacdStorage storage $ = _getSacdStorage();
+    uint256 version = $.tokenIdToVersion[asset][tokenId];
+    delete $.permissionRecords[asset][tokenId][version][msg.sender];
+
+    emit PermissionsRenounced(asset, tokenId, msg.sender);
+  }
+
+  /**
+   * @notice Allows a grantee to renounce their own account-level permission record from a grantor
+   * @dev The caller (msg.sender) is the grantee. Clears accountPermissionRecords[grantor][msg.sender].
+   *      Emits PermissionsRenounced with asset=grantor and tokenId=0, mirroring the convention
+   *      used by setAccountPermissions for PermissionsSet emits.
+   *      Always emits, even if no record exists.
+   * @param grantor The address that granted the permissions
+   */
+  function renounceAccountPermissions(address grantor) external {
+    SacdStorage storage $ = _getSacdStorage();
+    delete $.accountPermissionRecords[grantor][msg.sender];
+
+    emit PermissionsRenounced(grantor, 0, msg.sender);
+  }
+
+  /**
    * @notice Sets a payment record from the caller to a grantor
    * @dev Creates a new payment record and increments the payment ID counter.
    *      Either asset or currency must be specified, but not both.

--- a/contracts/interfaces/ISacd.sol
+++ b/contracts/interfaces/ISacd.sol
@@ -39,6 +39,7 @@ interface ISacd {
     uint256 expiration,
     string source
   );
+  event PermissionsRenounced(address indexed asset, uint256 indexed tokenId, address indexed grantee);
 
   error ZeroAddress();
   error Unauthorized(address addr);
@@ -67,6 +68,10 @@ interface ISacd {
     uint256 templateId,
     string calldata source
   ) external;
+
+  function renouncePermissions(address asset, uint256 tokenId) external;
+
+  function renounceAccountPermissions(address grantor) external;
 
   function setTemplateContract(address templateContractAddress) external;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
       "dependencies": {
         "@openzeppelin/contracts": "^5.0.2",
         "@openzeppelin/contracts-upgradeable": "^5.0.2",
-        "dotenv": "^16.4.5",
-        "hardhat": "^2.22.6"
+        "dotenv": "^16.4.5"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+        "hardhat": "^2.22.19",
         "hardhat-abi-exporter": "^2.11.0",
         "hardhat-tracer": "^3.1.0",
         "husky": "^9.1.0",
@@ -35,7 +35,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -144,6 +144,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
       "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -170,6 +171,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
       "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -194,6 +196,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
       "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -216,6 +219,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
       "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -238,6 +242,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
       "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -276,6 +281,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
       "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -296,6 +302,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
       "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -314,6 +321,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
       "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -360,6 +368,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
       "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -453,6 +462,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
       "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -472,6 +482,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
       "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -487,6 +498,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
       "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -525,6 +537,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
       "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -622,6 +635,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
       "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -662,6 +676,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
       "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -709,6 +724,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
       "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -729,6 +745,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
       "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -809,6 +826,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
       "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -854,6 +872,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -862,7 +881,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=6.0.0"
@@ -872,14 +891,14 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "devOptional": true,
+      "dev": true,
       "peer": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -890,6 +909,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
       "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
+      "dev": true,
       "dependencies": {
         "ethereumjs-abi": "^0.6.8",
         "ethereumjs-util": "^6.2.1",
@@ -931,6 +951,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
       "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -942,6 +963,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
       "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -988,74 +1010,90 @@
       }
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.4.2.tgz",
-      "integrity": "sha512-U7v0HuZHfrsl/5FpUzuB2FYA0+FUglHHwiO6NhvLtNYKMZcPzdS6iUriMp/7GWs0SVxW3bAht9GinZPxdhVwWg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.8.0.tgz",
+      "integrity": "sha512-dwWRrghSVBQDpt0wP+6RXD8BMz2i/9TI34TcmZqeEAZuCLei3U9KZRgGTKVAM1rMRvrpf5ROfPqrWNetKVUTag==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.4.2",
-        "@nomicfoundation/edr-darwin-x64": "0.4.2",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.4.2",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.4.2",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.4.2",
-        "@nomicfoundation/edr-linux-x64-musl": "0.4.2",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.4.2"
+        "@nomicfoundation/edr-darwin-arm64": "0.8.0",
+        "@nomicfoundation/edr-darwin-x64": "0.8.0",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.8.0",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.8.0",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.8.0",
+        "@nomicfoundation/edr-linux-x64-musl": "0.8.0",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.8.0"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.4.2.tgz",
-      "integrity": "sha512-S+hhepupfqpBvMa9M1PVS08sVjGXsLnjyAsjhrrsjsNuTHVLhKzhkguvBD5g4If5skrwgOaVqpag4wnQbd15kQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.8.0.tgz",
+      "integrity": "sha512-sKTmOu/P5YYhxT0ThN2Pe3hmCE/5Ag6K/eYoiavjLWbR7HEb5ZwPu2rC3DpuUk1H+UKJqt7o4/xIgJxqw9wu6A==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.4.2.tgz",
-      "integrity": "sha512-/zM94AUrXz6CmcsecRNHJ50jABDUFafmGc4iBmkfX/mTp4tVZj7XTyIogrQIt0FnTaeb4CgZoLap2+8tW/Uldg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.8.0.tgz",
+      "integrity": "sha512-8ymEtWw1xf1Id1cc42XIeE+9wyo3Dpn9OD/X8GiaMz9R70Ebmj2g+FrbETu8o6UM+aL28sBZQCiCzjlft2yWAg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.4.2.tgz",
-      "integrity": "sha512-TV3Pr2tFvvmCfPCi9PaCGLtqn+oLaPKfL2NWpnoCeFFdzDQXi2L930yP1oUPY5RXd78NLdVHMkEkbhb2b6Wuvg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.8.0.tgz",
+      "integrity": "sha512-h/wWzS2EyQuycz+x/SjMRbyA+QMCCVmotRsgM1WycPARvVZWIVfwRRsKoXKdCftsb3S8NTprqBdJlOmsFyETFA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.4.2.tgz",
-      "integrity": "sha512-PALwrLBk1M9rolXyhSX8xdhe5jL0qf/PgiCIF7W7lUyVKrI/I0oiU0EHDk/Xw7yi2UJg4WRyhhZoHYa0g4g8Qg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.8.0.tgz",
+      "integrity": "sha512-gnWxDgdkka0O9GpPX/gZT3REeKYV28Guyg13+Vj/bbLpmK1HmGh6Kx+fMhWv+Ht/wEmGDBGMCW1wdyT/CftJaQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.4.2.tgz",
-      "integrity": "sha512-5svkftypDjAZ1LxV1onojlaqPRxrTEjJLkrUwLL+Fao5ZMe7aTnk5QQ1Jv76gW6WYZnMXNgjPhRcnw3oSNrqFA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.8.0.tgz",
+      "integrity": "sha512-DTMiAkgAx+nyxcxKyxFZk1HPakXXUCgrmei7r5G7kngiggiGp/AUuBBWFHi8xvl2y04GYhro5Wp+KprnLVoAPA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.4.2.tgz",
-      "integrity": "sha512-qiMlXQTggdH9zfOB4Eil4rQ95z8s7QdLJcOfz5Aym12qJNkCyF9hi4cc4dDCWA0CdI3x3oLbuf8qb81SF8R45w==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.8.0.tgz",
+      "integrity": "sha512-iTITWe0Zj8cNqS0xTblmxPbHVWwEtMiDC+Yxwr64d7QBn/1W0ilFQ16J8gB6RVVFU3GpfNyoeg3tUoMpSnrm6Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.4.2.tgz",
-      "integrity": "sha512-hDkAb0iaMmGYwBY/rA1oCX8VpsezfQcHPEPIEGXEcWC3WbnOgIZo0Qkpu/g0OMtFOJSQlWLXvKZuV7blhnrQag==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.8.0.tgz",
+      "integrity": "sha512-mNRDyd/C3j7RMcwapifzv2K57sfA5xOw8g2U84ZDvgSrXVXLC99ZPxn9kmolb+dz8VMm9FONTZz9ESS6v8DTnA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       }
@@ -1064,6 +1102,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.4.tgz",
       "integrity": "sha512-9Rgb658lcWsjiicr5GzNCjI1llow/7r0k50dLL95OJ+6iZJcVbi15r3Y0xh2cIO+zgX0WIHcbzIu6FeQf9KPrg==",
+      "dev": true,
       "dependencies": {
         "@nomicfoundation/ethereumjs-util": "9.0.4"
       }
@@ -1072,6 +1111,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.4.tgz",
       "integrity": "sha512-8H1S3s8F6QueOc/X92SdrA4RDenpiAEqMg5vJH99kcQaCy/a3Q6fgseo75mgWlbanGJXSlAPtnCeG9jvfTYXlw==",
+      "dev": true,
       "bin": {
         "rlp": "bin/rlp.cjs"
       },
@@ -1083,6 +1123,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.4.tgz",
       "integrity": "sha512-Xjv8wAKJGMrP1f0n2PeyfFCCojHd7iS3s/Ab7qzF1S64kxZ8Z22LCMynArYsVqiFx6rzYy548HNVEyI+AYN/kw==",
+      "dev": true,
       "dependencies": {
         "@nomicfoundation/ethereumjs-common": "4.0.4",
         "@nomicfoundation/ethereumjs-rlp": "5.0.4",
@@ -1105,6 +1146,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
       "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "dev": true,
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -1127,6 +1169,7 @@
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.4.tgz",
       "integrity": "sha512-sLOzjnSrlx9Bb9EFNtHzK/FJFsfg2re6bsGqinFinH1gCqVfz9YYlXiMWwDM4C/L4ywuHFCYwfKTVr/QHQcU0Q==",
+      "dev": true,
       "dependencies": {
         "@nomicfoundation/ethereumjs-rlp": "5.0.4",
         "ethereum-cryptography": "0.1.3"
@@ -1147,6 +1190,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
       "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "dev": true,
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -1551,6 +1595,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.2.tgz",
       "integrity": "sha512-q4n32/FNKIhQ3zQGGw5CvPF6GTvDCpYwIf7bEY/dZTZbgfDsHyjJwURxUJf3VQuuJj+fDIFl4+KkBVbw4Ef6jA==",
+      "dev": true,
       "engines": {
         "node": ">= 12"
       },
@@ -1568,6 +1613,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.2.tgz",
       "integrity": "sha512-JaqcWPDZENCvm++lFFGjrDd8mxtf+CtLd2MiXvMNTBD33dContTZ9TWETwNFwg7JTJT5Q9HEecH7FA+HTSsIUw==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 12"
@@ -1577,6 +1623,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.2.tgz",
       "integrity": "sha512-fZNmVztrSXC03e9RONBT+CiksSeYcxI1wlzqyr0L7hsQlK1fzV+f04g2JtQ1c/Fe74ZwdV6aQBdd6Uwl1052sw==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 12"
@@ -1586,6 +1633,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.2.tgz",
       "integrity": "sha512-3d54oc+9ZVBuB6nbp8wHylk4xh0N0Gc+bk+/uJae+rUgbOBwQSfuGIbAZt1wBXs5REkSmynEGcqx6DutoK0tPA==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 12"
@@ -1595,6 +1643,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.2.tgz",
       "integrity": "sha512-iDJfR2qf55vgsg7BtJa7iPiFAsYf2d0Tv/0B+vhtnI16+wfQeTbP7teookbGvAo0eJo7aLLm0xfS/GTkvHIucA==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 12"
@@ -1604,6 +1653,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.2.tgz",
       "integrity": "sha512-9dlHMAt5/2cpWyuJ9fQNOUXFB/vgSFORg1jpjX1Mh9hJ/MfZXlDdHQ+DpFCs32Zk5pxRBb07yGvSHk9/fezL+g==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 12"
@@ -1613,6 +1663,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.2.tgz",
       "integrity": "sha512-GzzVeeJob3lfrSlDKQw2bRJ8rBf6mEYaWY+gW0JnTDHINA0s2gPR4km5RLIj1xeZZOYz4zRw+AEeYgLRqB2NXg==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 12"
@@ -1622,6 +1673,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.2.tgz",
       "integrity": "sha512-Fdjli4DCcFHb4Zgsz0uEJXZ2K7VEO+w5KVv7HmT7WO10iODdU9csC2az4jrhEsRtiR9Gfd74FlG0NYlw1BMdyA==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 12"
@@ -1644,6 +1696,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
       "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
+      "dev": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -1652,6 +1705,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
       "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1668,6 +1722,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
       "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1683,6 +1738,7 @@
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
       "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "dev": true,
       "dependencies": {
         "@sentry/hub": "5.30.0",
         "@sentry/minimal": "5.30.0",
@@ -1698,6 +1754,7 @@
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
       "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
+      "dev": true,
       "dependencies": {
         "@sentry/types": "5.30.0",
         "@sentry/utils": "5.30.0",
@@ -1711,6 +1768,7 @@
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
       "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
+      "dev": true,
       "dependencies": {
         "@sentry/hub": "5.30.0",
         "@sentry/types": "5.30.0",
@@ -1724,6 +1782,7 @@
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz",
       "integrity": "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==",
+      "dev": true,
       "dependencies": {
         "@sentry/core": "5.30.0",
         "@sentry/hub": "5.30.0",
@@ -1743,6 +1802,7 @@
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.30.0.tgz",
       "integrity": "sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==",
+      "dev": true,
       "dependencies": {
         "@sentry/hub": "5.30.0",
         "@sentry/minimal": "5.30.0",
@@ -1758,6 +1818,7 @@
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
       "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1766,6 +1827,7 @@
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
       "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+      "dev": true,
       "dependencies": {
         "@sentry/types": "5.30.0",
         "tslib": "^1.9.3"
@@ -1784,28 +1846,28 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "devOptional": true,
+      "dev": true,
       "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "peer": true
     },
     "node_modules/@typechain/ethers-v6": {
@@ -1883,6 +1945,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
       "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1938,7 +2001,8 @@
     "node_modules/@types/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -1958,6 +2022,7 @@
       "version": "20.14.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
       "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1966,6 +2031,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
       "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1988,6 +2054,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
       "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2003,7 +2070,7 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -2016,7 +2083,7 @@
       "version": "8.3.3",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
       "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "dependencies": {
         "acorn": "^8.11.0"
@@ -2029,6 +2096,7 @@
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
       "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.0"
       }
@@ -2044,6 +2112,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -2055,6 +2124,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -2095,6 +2165,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
       "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.1.0"
       }
@@ -2103,6 +2174,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2111,6 +2183,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -2125,6 +2198,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2133,6 +2207,8 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -2151,6 +2227,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2163,13 +2240,14 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-back": {
       "version": "3.1.0",
@@ -2267,12 +2345,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base-x": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
       "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -2287,6 +2367,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -2297,17 +2378,20 @@
     "node_modules/blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "dev": true
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true
     },
     "node_modules/boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
       "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dev": true,
       "dependencies": {
         "ansi-align": "^3.0.0",
         "camelcase": "^6.2.0",
@@ -2329,6 +2413,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2343,6 +2428,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2358,6 +2444,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2368,12 +2455,14 @@
     "node_modules/boxen/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/boxen/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2382,6 +2471,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2393,6 +2483,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2404,6 +2495,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2413,6 +2505,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -2423,17 +2516,20 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -2447,6 +2543,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dev": true,
       "dependencies": {
         "base-x": "^3.0.2"
       }
@@ -2455,6 +2552,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
       "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "dev": true,
       "dependencies": {
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
@@ -2464,17 +2562,20 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2503,6 +2604,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2566,6 +2668,8 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2602,6 +2706,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -2624,12 +2729,14 @@
     "node_modules/ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
     },
     "node_modules/cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -2639,6 +2746,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2647,6 +2755,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -2803,6 +2912,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -2813,6 +2923,8 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -2820,7 +2932,9 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2854,7 +2968,8 @@
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "dev": true
     },
     "node_modules/command-line-args": {
       "version": "5.2.1",
@@ -2920,7 +3035,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -2975,6 +3091,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2990,6 +3107,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -3002,6 +3120,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -3015,7 +3134,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "peer": true
     },
     "node_modules/cross-spawn": {
@@ -3053,6 +3172,7 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
       "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3069,6 +3189,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -3157,6 +3278,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3165,6 +3287,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -3210,6 +3333,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -3223,17 +3347,20 @@
     "node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -3246,6 +3373,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3277,6 +3405,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3285,6 +3414,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -3476,6 +3607,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
       "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+      "dev": true,
       "dependencies": {
         "@noble/hashes": "1.2.0",
         "@noble/secp256k1": "1.7.1",
@@ -3487,6 +3619,7 @@
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
       "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
+      "dev": true,
       "dependencies": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -3495,12 +3628,14 @@
     "node_modules/ethereumjs-abi/node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
     },
     "node_modules/ethereumjs-util": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
       "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+      "dev": true,
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -3515,6 +3650,7 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3522,12 +3658,14 @@
     "node_modules/ethereumjs-util/node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
     },
     "node_modules/ethereumjs-util/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
       "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "dev": true,
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -3650,6 +3788,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
       "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "dev": true,
       "dependencies": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
@@ -3669,6 +3808,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -3749,6 +3889,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3770,20 +3911,27 @@
       }
     },
     "node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -3792,6 +3940,7 @@
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3825,12 +3974,14 @@
     "node_modules/fp-ts": {
       "version": "1.19.3",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.3.tgz",
-      "integrity": "sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg=="
+      "integrity": "sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==",
+      "dev": true
     },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3850,12 +4001,14 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -3879,6 +4032,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -3966,6 +4120,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3985,6 +4140,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4069,7 +4225,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -4094,13 +4251,15 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.22.6",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.6.tgz",
-      "integrity": "sha512-abFEnd9QACwEtSvZZGSmzvw7N3zhQN1cDKz5SLHAupfG24qTHofCjqvD5kT5Wwsq5XOL0ON1Mq5rr4v0XX5ciw==",
+      "version": "2.22.19",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.19.tgz",
+      "integrity": "sha512-jptJR5o6MCgNbhd7eKa3mrteR+Ggq1exmE5RUL5ydQEVKcZm0sss5laa86yZ0ixIavIvF4zzS7TdGDuyopj0sQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/edr": "^0.4.1",
+        "@nomicfoundation/edr": "^0.8.0",
         "@nomicfoundation/ethereumjs-common": "4.0.4",
         "@nomicfoundation/ethereumjs-tx": "5.0.4",
         "@nomicfoundation/ethereumjs-util": "9.0.4",
@@ -4112,31 +4271,32 @@
         "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
         "boxen": "^5.1.2",
-        "chalk": "^2.4.2",
-        "chokidar": "^3.4.0",
+        "chokidar": "^4.0.0",
         "ci-info": "^2.0.0",
         "debug": "^4.1.1",
         "enquirer": "^2.3.0",
         "env-paths": "^2.2.0",
         "ethereum-cryptography": "^1.0.3",
         "ethereumjs-abi": "^0.6.8",
-        "find-up": "^2.1.0",
+        "find-up": "^5.0.0",
         "fp-ts": "1.19.3",
         "fs-extra": "^7.0.1",
-        "glob": "7.2.0",
         "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
+        "json-stream-stringify": "^3.1.4",
         "keccak": "^3.0.2",
         "lodash": "^4.17.11",
         "mnemonist": "^0.38.0",
         "mocha": "^10.0.0",
         "p-map": "^4.0.0",
+        "picocolors": "^1.1.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
         "solc": "0.8.26",
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
+        "tinyglobby": "^0.2.6",
         "tsort": "0.0.1",
         "undici": "^5.14.0",
         "uuid": "^8.3.2",
@@ -4336,10 +4496,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/hardhat/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/hardhat/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4387,6 +4579,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -4400,6 +4593,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -4422,6 +4616,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
       "bin": {
         "he": "bin/he"
       }
@@ -4437,6 +4632,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -4463,6 +4659,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -4495,6 +4692,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -4531,6 +4729,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -4562,12 +4761,14 @@
     "node_modules/immutable": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ=="
+      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
+      "dev": true
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4577,6 +4778,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4585,7 +4787,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -4608,6 +4811,7 @@
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.10.4.tgz",
       "integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
+      "dev": true,
       "dependencies": {
         "fp-ts": "^1.0.0"
       }
@@ -4616,6 +4820,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -4627,6 +4832,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4647,6 +4853,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -4658,6 +4865,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
+      "dev": true,
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
@@ -4667,6 +4875,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4675,6 +4884,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4695,6 +4905,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -4718,12 +4929,14 @@
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4738,6 +4951,16 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/json-stream-stringify": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz",
+      "integrity": "sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=7.10.1"
+      }
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -4749,6 +4972,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4767,6 +4991,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
       "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
@@ -4959,21 +5184,26 @@
       }
     },
     "node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -5007,6 +5237,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -5022,6 +5253,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -5036,6 +5268,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5051,6 +5284,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -5061,12 +5295,14 @@
     "node_modules/log-symbols/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5075,6 +5311,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -5236,13 +5473,14 @@
     "node_modules/lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
+      "dev": true
     },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "peer": true
     },
     "node_modules/markdown-table": {
@@ -5256,6 +5494,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -5266,6 +5505,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10.0"
       }
@@ -5344,17 +5584,20 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5388,6 +5631,7 @@
       "version": "0.38.5",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.5.tgz",
       "integrity": "sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==",
+      "dev": true,
       "dependencies": {
         "obliterator": "^2.0.0"
       }
@@ -5396,6 +5640,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.6.0.tgz",
       "integrity": "sha512-hxjt4+EEB0SA0ZDygSS015t65lJw/I2yRCS3Ae+SJ5FrbzrXgfYwJr96f0OvIXdj7h4lv/vLCrH3rkiuizFSvw==",
+      "dev": true,
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
@@ -5430,6 +5675,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -5438,21 +5684,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5465,6 +5697,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5483,28 +5716,16 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5515,48 +5736,14 @@
     "node_modules/mocha/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/mocha/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "engines": {
-        "node": ">=8"
-      }
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -5570,7 +5757,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/ndjson": {
       "version": "2.0.0",
@@ -5602,7 +5790,8 @@
     "node_modules/node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "dev": true
     },
     "node_modules/node-emoji": {
       "version": "1.11.0",
@@ -5618,6 +5807,7 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
       "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
+      "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -5651,6 +5841,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5730,12 +5921,14 @@
     "node_modules/obliterator": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
-      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==",
+      "dev": true
     },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5784,36 +5977,48 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "p-try": "^1.0.0"
+        "yocto-queue": "^0.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^3.0.2"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-map": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -5824,14 +6029,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -5840,17 +6037,20 @@
       "peer": true
     },
     "node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5867,7 +6067,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-starts-with": {
       "version": "2.0.1",
@@ -5903,6 +6104,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
       "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "dev": true,
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -5914,10 +6116,18 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -6080,6 +6290,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -6088,6 +6299,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -6102,6 +6314,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -6115,6 +6328,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -6188,6 +6402,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6206,6 +6421,7 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
       "dependencies": {
         "path-parse": "^1.0.6"
       },
@@ -6304,6 +6520,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -6313,6 +6530,7 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
       "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+      "dev": true,
       "dependencies": {
         "bn.js": "^5.2.0"
       },
@@ -6348,6 +6566,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6366,7 +6585,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/sc-istanbul": {
       "version": "0.4.6",
@@ -6496,12 +6716,14 @@
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true
     },
     "node_modules/secp256k1": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
       "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "elliptic": "^6.5.4",
@@ -6516,6 +6738,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -6524,6 +6747,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -6549,17 +6773,20 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -6701,6 +6928,7 @@
       "version": "0.8.26",
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.26.tgz",
       "integrity": "sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==",
+      "dev": true,
       "dependencies": {
         "command-exists": "^1.2.8",
         "commander": "^8.1.0",
@@ -6721,6 +6949,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -6729,6 +6958,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -6812,6 +7042,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6820,6 +7051,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -6846,6 +7078,7 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
       "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.7.1"
       },
@@ -6857,6 +7090,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6865,6 +7099,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6873,6 +7108,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -6897,6 +7133,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6910,6 +7147,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6918,6 +7156,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6941,6 +7180,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
       "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
+      "dev": true,
       "dependencies": {
         "is-hex-prefixed": "1.0.0"
       },
@@ -6953,6 +7193,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -6964,6 +7205,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -7168,10 +7411,59 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -7183,6 +7475,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -7194,6 +7487,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -7304,7 +7598,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -7348,7 +7642,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.3.1"
@@ -7357,22 +7651,26 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tsort": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
-      "integrity": "sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw=="
+      "integrity": "sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==",
+      "dev": true
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "dev": true
     },
     "node_modules/tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -7401,6 +7699,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -7495,7 +7794,7 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7533,6 +7832,7 @@
       "version": "5.28.4",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
       "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -7543,12 +7843,14 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -7557,6 +7859,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7571,12 +7874,14 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -7585,7 +7890,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "peer": true
     },
     "node_modules/web3-utils": {
@@ -7695,6 +8000,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.0.0"
       },
@@ -7746,12 +8052,14 @@
     "node_modules/workerpool": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA=="
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7768,6 +8076,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -7782,6 +8091,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -7792,17 +8102,20 @@
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -7823,6 +8136,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -7843,6 +8157,7 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -7860,6 +8175,7 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -7868,6 +8184,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
       "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
       "dependencies": {
         "camelcase": "^6.0.0",
         "decamelize": "^4.0.0",
@@ -7882,7 +8199,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -7892,6 +8209,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.2",
     "@openzeppelin/contracts-upgradeable": "^5.0.2",
-    "dotenv": "^16.4.5",
-    "hardhat": "^2.22.6"
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+    "hardhat": "^2.22.19",
     "hardhat-abi-exporter": "^2.11.0",
     "hardhat-tracer": "^3.1.0",
     "husky": "^9.1.0",

--- a/scripts/data/addresses.json
+++ b/scripts/data/addresses.json
@@ -1,6 +1,7 @@
 {
     "create3Deployer": "0xD64b27cA7F7d4447dFa8cb8701497Fb6eE774F6a",
     "polygon": {
+        "safe": "0xCED3c922200559128930180d3f0bfFd4d9f4F123",
         "Sacd": {
             "proxy": "0x3c152B5d96769661008Ff404224d6530FCAC766d",
             "implementation": "0x910d8Ab4e9a78D7f641BBC5DA3997fd21E5d7A30"
@@ -11,6 +12,7 @@
         }
     },
     "amoy": {
+        "safe": "",
         "Sacd": {
             "proxy": "0x4E5F9320b1c7cB3DE5ebDD760aD67375B66cF8a3",
             "implementation": "0x3d02BABb490A68977b3760fed85Ce877907c200C"

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -13,44 +13,140 @@ async function getGasPrice(bump: bigint = 20n): Promise<bigint> {
   return (price * bump) / 100n + price
 }
 
+const networkChainIds: Record<string, number> = {
+  polygon: 137,
+  amoy: 80002,
+}
+
 /**
- * Upgrades the Sacd contract (uses regular deployment)
+ * Deploys a new Sacd implementation and writes it to addresses.json.
+ * Does not touch the proxy. Any funded signer can call this — implementation
+ * deploys are not access-controlled.
  */
-async function upgradeSacd(signer: HardhatEthersSigner, networkName: string) {
+async function deploySacdImplementation(deployer: HardhatEthersSigner, networkName: string): Promise<string> {
   const gasPrice = await getGasPrice(20n)
-  const instances = getAddresses()
 
-  const sacdProxy = instances[networkName].Sacd.proxy
+  console.log(`\n===== Deploying Sacd Implementation =====`)
+  console.log(`Network: ${networkName}`)
+  console.log(`Deployer: ${deployer.address}\n`)
 
-  if (!sacdProxy) {
-    throw new Error(`Sacd proxy address not found for network: ${networkName}`)
-  }
-
-  console.log(`\n===== Upgrading Sacd Contract =====`)
-  console.log(`Proxy: ${sacdProxy}`)
-  console.log(`Current Implementation: ${instances[networkName].Sacd.implementation}\n`)
-
-  const factory = await ethers.getContractFactory('Sacd', signer)
-
-  const impl = await factory.deploy({ gasPrice: gasPrice })
+  const factory = await ethers.getContractFactory('Sacd', deployer)
+  const impl = await factory.deploy({ gasPrice })
   await impl.waitForDeployment()
   const addressImpl = await impl.getAddress()
 
   console.log(`New implementation deployed at: ${addressImpl}`)
 
-  const proxy = await ethers.getContractAt('Sacd', sacdProxy, signer)
-  const upgradeTx = await proxy.upgradeToAndCall(addressImpl, '0x')
+  const instances = getAddresses()
+  instances[networkName].Sacd.implementation = addressImpl
+  writeAddresses(instances, networkName)
+
+  return addressImpl
+}
+
+/**
+ * Calls upgradeToAndCall on the Sacd proxy. The signer must hold UPGRADER_ROLE.
+ * Reads the new implementation address from addresses.json (must already be deployed).
+ */
+async function upgradeSacdProxy(upgrader: HardhatEthersSigner, networkName: string) {
+  const instances = getAddresses()
+  const sacdProxy = instances[networkName].Sacd.proxy
+  const newImpl = instances[networkName].Sacd.implementation
+
+  if (!sacdProxy) {
+    throw new Error(`Sacd proxy address not found for network: ${networkName}`)
+  }
+  if (!newImpl) {
+    throw new Error(`Sacd implementation address not found for network: ${networkName}. Run the deploy step first.`)
+  }
+
+  console.log(`\n===== Upgrading Sacd Proxy =====`)
+  console.log(`Proxy: ${sacdProxy}`)
+  console.log(`New Implementation: ${newImpl}`)
+  console.log(`Upgrader: ${upgrader.address}\n`)
+
+  const proxy = await ethers.getContractAt('Sacd', sacdProxy, upgrader)
+  const upgradeTx = await proxy.upgradeToAndCall(newImpl, '0x')
   console.log(`Upgrade transaction sent: ${upgradeTx.hash}`)
 
   const upgradeReceipt = await upgradeTx.wait()
   console.log(`Upgrade confirmed in block: ${upgradeReceipt?.blockNumber}`)
 
-  console.log(`\nSacd contract upgraded successfully!`)
+  console.log(`\nSacd proxy upgraded successfully!`)
   console.log(`Proxy: ${sacdProxy}`)
-  console.log(`New Implementation: ${addressImpl}\n`)
+  console.log(`Now pointing to: ${newImpl}\n`)
+}
 
-  instances[networkName].Sacd.implementation = addressImpl
-  writeAddresses(instances, networkName)
+/**
+ * Single-shot Sacd upgrade for the EOA path: same signer deploys and upgrades.
+ * Used on networks where UPGRADER_ROLE is held by an EOA we control (e.g. Amoy).
+ */
+async function upgradeSacd(signer: HardhatEthersSigner, networkName: string) {
+  await deploySacdImplementation(signer, networkName)
+  await upgradeSacdProxy(signer, networkName)
+}
+
+/**
+ * Prints the calldata and Safe Tx Builder JSON for upgradeToAndCall(newImpl, "0x").
+ * Use on networks where UPGRADER_ROLE is held by a Safe (e.g. Polygon).
+ * Assumes the new implementation has already been deployed and recorded.
+ */
+async function printSacdSafeUpgradeCalldata(networkName: string) {
+  const instances = getAddresses()
+  const sacdProxy = instances[networkName].Sacd.proxy
+  const newImpl = instances[networkName].Sacd.implementation
+  const safe = instances[networkName].safe
+
+  if (!sacdProxy) {
+    throw new Error(`Sacd proxy address not found for network: ${networkName}`)
+  }
+  if (!newImpl) {
+    throw new Error(`Sacd implementation address not found for network: ${networkName}. Run the deploy step first.`)
+  }
+  if (!safe) {
+    throw new Error(
+      `Safe address not set for network "${networkName}". Add the "safe" field in scripts/data/addresses.json.`
+    )
+  }
+  const chainId = networkChainIds[networkName]
+  if (!chainId) {
+    throw new Error(`Unknown chainId for network "${networkName}".`)
+  }
+
+  const factory = await ethers.getContractFactory('Sacd')
+  const data = factory.interface.encodeFunctionData('upgradeToAndCall', [newImpl, '0x'])
+
+  console.log(`\n===== Safe Transaction =====`)
+  console.log(`Submit from Safe: ${safe} (chainId ${chainId})`)
+  console.log(`  to:    ${sacdProxy}`)
+  console.log(`  value: 0`)
+  console.log(`  data:  ${data}`)
+
+  const txBuilder = {
+    version: '1.0',
+    chainId: String(chainId),
+    createdAt: Date.now(),
+    meta: {
+      name: 'Sacd upgradeToAndCall',
+      description: `Upgrade Sacd proxy ${sacdProxy} to implementation ${newImpl}`,
+      txBuilderVersion: '1.16.5',
+      createdFromSafeAddress: safe,
+      createdFromOwnerAddress: '',
+    },
+    transactions: [
+      {
+        to: sacdProxy,
+        value: '0',
+        data,
+        contractMethod: null,
+        contractInputsValues: null,
+      },
+    ],
+  }
+
+  console.log(`\nTx Builder JSON (paste into Safe Tx Builder → Import):\n`)
+  console.log(JSON.stringify(txBuilder, null, 2))
+  console.log()
 }
 
 /**
@@ -149,22 +245,24 @@ async function upgradeTemplateProxy(upgrader: HardhatEthersSigner, networkName: 
 async function main() {
   let [deployer, user1] = await ethers.getSigners()
   let { name } = await ethers.provider.getNetwork()
+  const isLocalhost = name === 'localhost'
 
   // Signers for different roles
   let create3Deployer = deployer
   let upgrader = deployer
 
-  if (name === 'localhost') {
-    name = 'polygon'
-    // 0xCED3c922200559128930180d3f0bfFd4d9f4F123 Prod account
-    // 0x1741ec2915ab71fc03492715b5640133da69420b Prod deployer/manager
-    // 0xC008EF40B0b42AAD7e34879EB024385024f753ea Shared dev account (has UPGRADER_ROLE)
+  if (isLocalhost) {
+    // FORK selects which chain we're forking; defaults to polygon for back-compat.
+    name = process.env.FORK?.toLowerCase() || 'polygon'
+    // 0xCED3c922200559128930180d3f0bfFd4d9f4F123 Deployer Safe (holds UPGRADER_ROLE on Polygon — use MODE=safe)
+    // 0x1741ec2915ab71fc03492715b5640133da69420b Prod deployer/manager EOA
+    // 0xC008EF40B0b42AAD7e34879EB024385024f753ea Shared dev account (has UPGRADER_ROLE on Amoy)
     // 0xD64b27cA7F7d4447dFa8cb8701497Fb6eE774F6a Deployer create3 (designated CREATE3 deployer)
 
     const designatedDeployer = getCreate3Deployer()
     create3Deployer = await ethers.getImpersonatedSigner(designatedDeployer)
     upgrader = await ethers.getImpersonatedSigner(
-      name == 'polygon' ? '0x1741ec2915ab71fc03492715b5640133da69420b' : '0xC008EF40B0b42AAD7e34879EB024385024f753ea'
+      name === 'polygon' ? '0x1741ec2915ab71fc03492715b5640133da69420b' : '0xC008EF40B0b42AAD7e34879EB024385024f753ea'
     )
 
     // Fund both accounts
@@ -179,18 +277,47 @@ async function main() {
   }
 
   console.log(`\n========================================`)
-  console.log(`Network: ${name}`)
+  console.log(`Network: ${name}${isLocalhost ? ' (forked via localhost)' : ''}`)
   console.log(`CREATE3 Deployer: ${create3Deployer.address}`)
   console.log(`Upgrader: ${upgrader.address}`)
   console.log(`========================================`)
 
   try {
-    // Get contract and version from environment variables
+    // Get contract, mode, and version from environment variables
     const contract = process.env.CONTRACT?.toLowerCase()
+    const mode = process.env.MODE?.toLowerCase()
     const version = process.env.VERSION || '1.0.2'
 
     if (contract === 'sacd') {
-      await upgradeSacd(upgrader, name)
+      if (mode === 'safe') {
+        // Safe path: deploy impl with the funded EOA, then either execute (localhost
+        // simulation by impersonating the Safe) or print calldata for Safe submission.
+        const safe = getAddresses()[name].safe
+        if (!safe) {
+          throw new Error(
+            `Safe address not set for "${name}" in scripts/data/addresses.json. Fill in the "safe" field before running MODE=safe.`
+          )
+        }
+
+        await deploySacdImplementation(deployer, name)
+
+        if (isLocalhost) {
+          console.log(`\n===== Simulating Safe Upgrade =====`)
+          console.log(`Impersonating Safe: ${safe}`)
+          const safeSigner = await ethers.getImpersonatedSigner(safe)
+          await user1.sendTransaction({
+            to: safe,
+            value: ethers.parseEther('10'),
+          })
+          await upgradeSacdProxy(safeSigner, name)
+          console.log(`✅ Safe upgrade simulation complete on forked ${name}.`)
+        } else {
+          await printSacdSafeUpgradeCalldata(name)
+          console.log(`\nNext: import the JSON above into the Safe Tx Builder, collect signatures, execute.`)
+        }
+      } else {
+        await upgradeSacd(upgrader, name)
+      }
     } else if (contract === 'template-impl') {
       // Step 1: Deploy new implementation with CREATE3
       await deployTemplateImplementation(create3Deployer, name, version)
@@ -210,8 +337,16 @@ async function main() {
       await upgradeTemplateProxy(upgrader, name)
     } else {
       console.log('\nUsage with environment variables:')
-      console.log('\nSacd Contract:')
-      console.log('  CONTRACT=sacd npx hardhat run scripts/upgrade.ts')
+      console.log('\nSacd Contract (EOA path — UPGRADER_ROLE held by signer):')
+      console.log('  CONTRACT=sacd npx hardhat run scripts/upgrade.ts --network amoy')
+      console.log('\nSacd Contract (Safe path — UPGRADER_ROLE held by Gnosis Safe):')
+      console.log('  Real:    CONTRACT=sacd MODE=safe npx hardhat run scripts/upgrade.ts --network polygon')
+      console.log(
+        '  Forked:  CONTRACT=sacd MODE=safe FORK=polygon npx hardhat run scripts/upgrade.ts --network localhost'
+      )
+      console.log(
+        '  (real network deploys impl + prints Safe Tx Builder JSON; localhost impersonates the Safe and executes)'
+      )
       console.log('\nTemplate Contract (two-step process):')
       console.log('  Step 1: Deploy implementation')
       console.log('    CONTRACT=template-impl VERSION=1.0.2 npx hardhat run scripts/upgrade.ts')
@@ -236,7 +371,14 @@ async function main() {
   }
 }
 
-export { upgradeSacd, deployTemplateImplementation, upgradeTemplateProxy }
+export {
+  upgradeSacd,
+  deploySacdImplementation,
+  upgradeSacdProxy,
+  printSacdSafeUpgradeCalldata,
+  deployTemplateImplementation,
+  upgradeTemplateProxy,
+}
 
 if (require.main === module) {
   main()

--- a/test/Sacd.test.ts
+++ b/test/Sacd.test.ts
@@ -527,6 +527,225 @@ describe('Sacd', function () {
     })
   })
 
+  describe('renouncePermissions', () => {
+    context('State', () => {
+      it('Should clear the permission record for the renouncing grantee', async () => {
+        const { mockErc721, sacd, grantor, grantee, DEFAULT_EXPIRATION } = await loadFixture(setup)
+        const mockErc721Address = await mockErc721.getAddress()
+
+        await sacd
+          .connect(grantor)
+          [
+            'setPermissions(address,uint256,address,uint256,uint256,uint256,string)'
+          ](mockErc721Address, 1n, grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+
+        expect(await sacd.hasPermission(mockErc721Address, 1n, grantee.address, 2)).to.be.true
+
+        await sacd.connect(grantee).renouncePermissions(mockErc721Address, 1n)
+
+        const pr = await sacd.permissionRecords(mockErc721Address, 1n, 1n, grantee.address)
+        expect(pr.permissions).to.equal(0n)
+        expect(pr.expiration).to.equal(0n)
+        expect(pr.templateId).to.equal(0n)
+        expect(pr.source).to.equal('')
+        expect(await sacd.hasPermission(mockErc721Address, 1n, grantee.address, 2)).to.be.false
+      })
+      it('Should be a no-op on state when the grantee has no record under (asset, tokenId)', async () => {
+        const { mockErc721, sacd, grantee } = await loadFixture(setup)
+        const mockErc721Address = await mockErc721.getAddress()
+
+        await expect(sacd.connect(grantee).renouncePermissions(mockErc721Address, 1n)).to.not.be.reverted
+
+        const pr = await sacd.permissionRecords(mockErc721Address, 1n, 1n, grantee.address)
+        expect(pr.permissions).to.equal(0n)
+        expect(pr.expiration).to.equal(0n)
+      })
+      it('Should not affect other grantees on the same token', async () => {
+        const { mockErc721, sacd, grantor, grantee, otherAccount, DEFAULT_EXPIRATION } = await loadFixture(setup)
+        const mockErc721Address = await mockErc721.getAddress()
+
+        await sacd
+          .connect(grantor)
+          [
+            'setPermissions(address,uint256,address,uint256,uint256,uint256,string)'
+          ](mockErc721Address, 1n, grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+        await sacd
+          .connect(grantor)
+          [
+            'setPermissions(address,uint256,address,uint256,uint256,uint256,string)'
+          ](mockErc721Address, 1n, otherAccount.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+
+        await sacd.connect(grantee).renouncePermissions(mockErc721Address, 1n)
+
+        const renouncedPr = await sacd.permissionRecords(mockErc721Address, 1n, 1n, grantee.address)
+        expect(renouncedPr.permissions).to.equal(0n)
+
+        const otherPr = await sacd.permissionRecords(mockErc721Address, 1n, 1n, otherAccount.address)
+        expect(otherPr.permissions).to.equal(C.MOCK_PERMISSIONS)
+        expect(await sacd.hasPermission(mockErc721Address, 1n, otherAccount.address, 2)).to.be.true
+      })
+      it('Should not affect grants on other tokens', async () => {
+        const { mockErc721, sacd, grantor, grantee, DEFAULT_EXPIRATION } = await loadFixture(setup)
+        const mockErc721Address = await mockErc721.getAddress()
+
+        await mockErc721.mint(grantor.address)
+
+        await sacd
+          .connect(grantor)
+          [
+            'setPermissions(address,uint256,address,uint256,uint256,uint256,string)'
+          ](mockErc721Address, 1n, grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+        await sacd
+          .connect(grantor)
+          [
+            'setPermissions(address,uint256,address,uint256,uint256,uint256,string)'
+          ](mockErc721Address, 2n, grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+
+        await sacd.connect(grantee).renouncePermissions(mockErc721Address, 1n)
+
+        expect(await sacd.hasPermission(mockErc721Address, 1n, grantee.address, 2)).to.be.false
+        expect(await sacd.hasPermission(mockErc721Address, 2n, grantee.address, 2)).to.be.true
+      })
+      it('Should not change the token-owner permission short-circuit', async () => {
+        const { mockErc721, sacd, grantor } = await loadFixture(setup)
+        const mockErc721Address = await mockErc721.getAddress()
+
+        // grantor is the token owner; their renounce clears any explicit record
+        // but ownerOf-based permissions in hasPermission still return true.
+        await sacd.connect(grantor).renouncePermissions(mockErc721Address, 1n)
+
+        expect(await sacd.hasPermission(mockErc721Address, 1n, grantor.address, 2)).to.be.true
+        expect(await sacd.hasPermission(mockErc721Address, 1n, grantor.address, 4)).to.be.true
+      })
+    })
+
+    context('Events', () => {
+      it('Should emit PermissionsRenounced with correct params', async () => {
+        const { mockErc721, sacd, grantor, grantee, DEFAULT_EXPIRATION } = await loadFixture(setup)
+        const mockErc721Address = await mockErc721.getAddress()
+
+        await sacd
+          .connect(grantor)
+          [
+            'setPermissions(address,uint256,address,uint256,uint256,uint256,string)'
+          ](mockErc721Address, 1n, grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+
+        await expect(sacd.connect(grantee).renouncePermissions(mockErc721Address, 1n))
+          .to.emit(sacd, 'PermissionsRenounced')
+          .withArgs(mockErc721Address, 1n, grantee.address)
+      })
+      it('Should not emit PermissionsSet on the renounce path', async () => {
+        const { mockErc721, sacd, grantor, grantee, DEFAULT_EXPIRATION } = await loadFixture(setup)
+        const mockErc721Address = await mockErc721.getAddress()
+
+        await sacd
+          .connect(grantor)
+          [
+            'setPermissions(address,uint256,address,uint256,uint256,uint256,string)'
+          ](mockErc721Address, 1n, grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+
+        await expect(sacd.connect(grantee).renouncePermissions(mockErc721Address, 1n)).to.not.emit(
+          sacd,
+          'PermissionsSet'
+        )
+      })
+      it('Should still emit when no record exists', async () => {
+        const { mockErc721, sacd, grantee } = await loadFixture(setup)
+        const mockErc721Address = await mockErc721.getAddress()
+
+        await expect(sacd.connect(grantee).renouncePermissions(mockErc721Address, 1n))
+          .to.emit(sacd, 'PermissionsRenounced')
+          .withArgs(mockErc721Address, 1n, grantee.address)
+      })
+    })
+  })
+
+  describe('renounceAccountPermissions', () => {
+    context('State', () => {
+      it('Should clear the account permission record for the renouncing grantee', async () => {
+        const { sacd, grantor, grantee, DEFAULT_EXPIRATION } = await loadFixture(setup)
+
+        await sacd
+          .connect(grantor)
+          .setAccountPermissions(grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+
+        expect(await sacd.hasAccountPermission(grantor.address, grantee.address, 2)).to.be.true
+
+        await sacd.connect(grantee).renounceAccountPermissions(grantor.address)
+
+        const pr = await sacd.accountPermissionRecords(grantor.address, grantee.address)
+        expect(pr.permissions).to.equal(0n)
+        expect(pr.expiration).to.equal(0n)
+        expect(pr.templateId).to.equal(0n)
+        expect(pr.source).to.equal('')
+        expect(await sacd.hasAccountPermission(grantor.address, grantee.address, 2)).to.be.false
+      })
+      it('Should be a no-op on state when the grantee has no record under the grantor', async () => {
+        const { sacd, grantor, grantee } = await loadFixture(setup)
+
+        await expect(sacd.connect(grantee).renounceAccountPermissions(grantor.address)).to.not.be.reverted
+
+        const pr = await sacd.accountPermissionRecords(grantor.address, grantee.address)
+        expect(pr.permissions).to.equal(0n)
+      })
+      it('Should not affect a separate grant from a different grantor to the same grantee', async () => {
+        const { sacd, grantor, grantee, otherAccount, DEFAULT_EXPIRATION } = await loadFixture(setup)
+
+        await sacd
+          .connect(grantor)
+          .setAccountPermissions(grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+        await sacd
+          .connect(otherAccount)
+          .setAccountPermissions(grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+
+        await sacd.connect(grantee).renounceAccountPermissions(grantor.address)
+
+        expect(await sacd.hasAccountPermission(grantor.address, grantee.address, 2)).to.be.false
+        expect(await sacd.hasAccountPermission(otherAccount.address, grantee.address, 2)).to.be.true
+      })
+      it('Self-renounce does not break the grantor==grantee short-circuit', async () => {
+        const { sacd, grantor } = await loadFixture(setup)
+
+        await sacd.connect(grantor).renounceAccountPermissions(grantor.address)
+
+        expect(await sacd.hasAccountPermission(grantor.address, grantor.address, 2)).to.be.true
+      })
+    })
+
+    context('Events', () => {
+      it('Should emit PermissionsRenounced with grantor in asset slot and tokenId=0', async () => {
+        const { sacd, grantor, grantee, DEFAULT_EXPIRATION } = await loadFixture(setup)
+
+        await sacd
+          .connect(grantor)
+          .setAccountPermissions(grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+
+        await expect(sacd.connect(grantee).renounceAccountPermissions(grantor.address))
+          .to.emit(sacd, 'PermissionsRenounced')
+          .withArgs(grantor.address, 0n, grantee.address)
+      })
+      it('Should not emit PermissionsSet on the renounce path', async () => {
+        const { sacd, grantor, grantee, DEFAULT_EXPIRATION } = await loadFixture(setup)
+
+        await sacd
+          .connect(grantor)
+          .setAccountPermissions(grantee.address, C.MOCK_PERMISSIONS, DEFAULT_EXPIRATION, 0n, C.MOCK_SACD_SOURCE)
+
+        await expect(sacd.connect(grantee).renounceAccountPermissions(grantor.address)).to.not.emit(
+          sacd,
+          'PermissionsSet'
+        )
+      })
+      it('Should still emit when no record exists', async () => {
+        const { sacd, grantor, grantee } = await loadFixture(setup)
+
+        await expect(sacd.connect(grantee).renounceAccountPermissions(grantor.address))
+          .to.emit(sacd, 'PermissionsRenounced')
+          .withArgs(grantor.address, 0n, grantee.address)
+      })
+    })
+  })
+
   describe('setPayment', () => {
     context('Error handling', () => {
       it('Should revert if grantor is address(0)', async () => {


### PR DESCRIPTION
Adds two new functions that grantees can call to get rid of permissions granted to them:

- `renouncePermissions(address asset, uint256 tokenId)`
- `renounceAccountPermissions(address grantor)`

These emit a new `PermissionsRenounced(address asset, uint256 tokenId, address grantee)` (all arguments indexed) event. Here grantee is `msg.sender`, and `tokenId` is zero for account permissions. These do _not_ emit `PermissionsSet`, so event readers need to handle this new event to maintain correct state.